### PR TITLE
wrong global --bundle/--dab input

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -71,7 +71,7 @@ func validateFlags(c *cli.Context, opt *kobject.ConvertOptions) {
 		opt.InputFile = dabFile
 	}
 
-	if len(dabFile) > 0 && len(opt.InputFile) > 0 && opt.InputFile != DefaultComposeFile {
+	if len(dabFile) > 0 && c.GlobalIsSet("file") {
 		logrus.Fatalf("Error: 'compose' file and 'dab' file cannot be specified at the same time")
 	}
 }


### PR DESCRIPTION
An immediate fix to resolve the use of --bundle/--dab in order to resume work with adding test support for bundles.