### PR TITLE
New slack channel link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kompose (Kubernetes + Compose)
 
-[![Build Status](https://travis-ci.org/kubernetes-incubator/kompose.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/kompose) [![Join us on Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](https://skippbox.herokuapp.com)
+[![Build Status](https://travis-ci.org/kubernetes-incubator/kompose.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/kompose) [![Join us on Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](http://slack.k8s.io/)
 
 `kompose` is a tool to help users who are familiar with `docker-compose` move to [Kubernetes](http://kubernetes.io). `kompose` takes a Docker Compose file and translates it into Kubernetes resources.
 
@@ -93,7 +93,7 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 
 You can reach the maintainers of this project at:
 
-- [Slack](https://skippbox.herokuapp.com): #kompose
+- [Slack](http://slack.k8s.io/): #kompose
 
 Incubation of `kompose` into the Kubernetes project is shepherd in the [SIG-APPS](https://github.com/kubernetes/community).
 


### PR DESCRIPTION
Updated link of slack channel in README to http://slack.k8s.io/

Fixes #222