### PR TITLE
Add support for user directive

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package kubernetes
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 /*
@@ -49,7 +51,7 @@ func TestCreateService(t *testing.T) {
 		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
-		User:          "user", // not supported
+		User:          "user",
 	}
 
 	// An example object generated via k8s runtime.Objects()
@@ -64,4 +66,52 @@ func TestCreateService(t *testing.T) {
 	if svc.Spec.Ports[0].Port != 123 {
 		t.Errorf("Expected port 123 upon conversion, actual %d", svc.Spec.Ports[0].Port)
 	}
+}
+
+/*
+	Test the creation of a service with a specified user.
+	The expected result is that Kompose will set user in PodSpec
+*/
+func TestCreateServiceWithServiceUser(t *testing.T) {
+
+	// An example service
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolTCP}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		Volumes:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		Labels:        nil,
+		Annotations:   map[string]string{"kompose.service.type": "nodeport"},
+		CPUSet:        "cpu_set",            // not supported
+		CPUShares:     1,                    // not supported
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "1234",
+	}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+
+	objects := k.Transform(komposeObject, kobject.ConvertOptions{CreateD: true, Replicas: 1})
+
+	for _, obj := range objects {
+		if deploy, ok := obj.(*extensions.Deployment); ok {
+			uid := *deploy.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser
+			if strconv.FormatInt(uid, 10) != service.User {
+				t.Errorf("User in ServiceConfig is not matching user in PodSpec")
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
This is little a bit user unfriendly :-(

Issue is that in docker-compose you can set `user` by user name or uid. But K8S allows you to set user only by its uid (has to be int).

This is why I added warning that tells user that `user` directive will be ignored if its not a number.
Here is user unfriendly part, in docker-compose even if you set user by it uid, it has to be string. (user: "2324") If you set it as int (user: 2324) libcompose parser will complain about this not being string.

So now Kompose requires `user` to be number but written as string :-(

fixes #244 
