### PR TITLE
Tests for CreateService and annotations

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 Skippbox, Ltd All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"github.com/kubernetes-incubator/kompose/pkg/kobject"
+	"k8s.io/kubernetes/pkg/api"
+	"testing"
+)
+
+/*
+	Test the creation of a service
+*/
+func TestCreateService(t *testing.T) {
+
+	// An example service
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolTCP}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		Volumes:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		Labels:        nil,
+		Annotations:   map[string]string{"abc": "def"},
+		CPUSet:        "cpu_set",            // not supported
+		CPUShares:     1,                    // not supported
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "user", // not supported
+	}
+
+	// An example object generated via k8s runtime.Objects()
+	kompose_object := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+	objects := k.Transform(kompose_object, kobject.ConvertOptions{CreateD: true, Replicas: 3})
+
+	// Test the creation of the service
+	svc := k.CreateService("foo", service, objects)
+	if svc.Spec.Ports[0].Port != 123 {
+		t.Errorf("Expected port 123 upon conversion, actual %d", svc.Spec.Ports[0].Port)
+	}
+}
+
+/*
+	Test the creation of a service with a specified annotation (kompose.service.type) as "nodeport".
+	The expected result is that Kompose will convert the spec type to "NodePort" upon generation.
+*/
+func TestCreateServiceWithServiceTypeNodePort(t *testing.T) {
+
+	// An example service
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolTCP}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		Volumes:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		Labels:        nil,
+		Annotations:   map[string]string{"kompose.service.type": "nodeport"},
+		CPUSet:        "cpu_set",            // not supported
+		CPUShares:     1,                    // not supported
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "user", // not supported
+	}
+
+	// An example object generated via k8s runtime.Objects()
+	kompose_object := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+	tests := []struct {
+		labelValue  string
+		serviceType string
+	}{
+		{"NodePort", "NodePort"},
+		{"nodeport", "NodePort"},
+		{"LoadBalancer", "LoadBalancer"},
+		{"loadbalancer", "LoadBalancer"},
+		{"ClusterIP", "ClusterIP"},
+		{"clusterip", "ClusterIP"},
+	}
+
+	for _, tt := range tests {
+		kompose_object.ServiceConfigs["app"].Annotations["kompose.service.type"] = tt.labelValue
+
+		objects := k.Transform(kompose_object, kobject.ConvertOptions{CreateD: true, Replicas: 3})
+
+		// Test the creation of the service with modified annotations (kompose.service.type)
+		svc := k.CreateService("foo", service, objects)
+		if svc.Spec.Type != api.ServiceType(tt.serviceType) {
+			t.Errorf("Expected NodePort, actual %d", svc.Spec.Type)
+		}
+	}
+}


### PR DESCRIPTION
Adds some tests for CreateService, specifically the initial generation
as well as providing an edge case when specifying "kompose.service.type"
