### PR TITLE
Improve test times by removing "-race"

### DIFF
--- a/script/test-unit
+++ b/script/test-unit
@@ -18,4 +18,4 @@ set -e
 
 source "$(dirname "$BASH_SOURCE")/.build"
 
-go test "${BUILD_FLAGS[@]}" -race -cover -v $( go list github.com/kubernetes-incubator/kompose/... | grep -v '/vendor/' )
+go test "${BUILD_FLAGS[@]}" -cover -v $( go list github.com/kubernetes-incubator/kompose/... | grep -v '/vendor/' )


### PR DESCRIPTION
Improve test times by removing the -race condition on running the unit
tests