### PR TITLE
Update TRAVIS CI to add coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ language: go
 go:
   - 1.6
 
+before_install:
+  - go get github.com/mattn/goveralls
+
 install:
   - true
 
@@ -23,3 +26,4 @@ script:
   - cp kompose $GOPATH/bin/
 
   - make test-cmd
+  - goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kompose (Kubernetes + Compose)
 
 [![Build Status](https://travis-ci.org/kubernetes-incubator/kompose.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/kompose)
+[![Coverage Status](https://coveralls.io/repos/github/kubernetes-incubator/kompose/badge.svg?branch=master)](https://coveralls.io/github/kubernetes-incubator/kompose?branch=master)
 
 [![Join us in #kompose on k8s Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](http://slack.kubernetes.io) in #kompose channel
 


### PR DESCRIPTION
Updates travis to enable coveralls support.

Fixes https://github.com/kubernetes-incubator/kompose/issues/281