### PR TITLE
Added volume to mariadb in etherpad fixture

### DIFF
--- a/script/test/fixtures/etherpad/docker-compose.yml
+++ b/script/test/fixtures/etherpad/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       MYSQL_DATABASE: $DB_NAME
       MYSQL_PASSWORD: $DB_PASS
       MYSQL_USER: $DB_USER
+    volumes:
+      - /var/lib/mysql
 
   etherpad:
     image: centos/etherpad

--- a/script/test/fixtures/etherpad/output-k8s.json
+++ b/script/test/fixtures/etherpad/output-k8s.json
@@ -4,59 +4,31 @@
   "metadata": {},
   "items": [
     {
-      "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "kind": "Service",
+      "apiVersion": "v1",
       "metadata": {
-        "name": "mariadb",
-        "creationTimestamp": null
+        "name": "etherpad",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "etherpad"
+        }
       },
       "spec": {
-        "replicas": 1,
-        "template": {
-          "metadata": {
-            "creationTimestamp": null,
-            "labels": {
-              "service": "mariadb"
-            }
-          },
-          "spec": {
-            "containers": [
-              {
-                "name": "mariadb",
-                "image": "centos/mariadb",
-                "ports": [
-                  {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
-                  }
-                ],
-                "env": [
-                  {
-                    "name": "MYSQL_DATABASE",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_PASSWORD",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_USER",
-                    "value": "etherpad"
-                  }
-                ],
-                "resources": {}
-              }
-            ],
-            "restartPolicy": "Always"
+        "ports": [
+          {
+            "name": "80",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 9001
           }
-        },
-        "strategy": {}
+        ],
+        "selector": {
+          "service": "etherpad"
+        }
       },
-      "status": {}
+      "status": {
+        "loadBalancer": {}
+      }
     },
     {
       "kind": "Service",
@@ -114,10 +86,6 @@
                 ],
                 "env": [
                   {
-                    "name": "DB_USER",
-                    "value": "etherpad"
-                  },
-                  {
                     "name": "DB_DBID",
                     "value": "etherpad"
                   },
@@ -132,6 +100,10 @@
                   {
                     "name": "DB_PORT",
                     "value": "3306"
+                  },
+                  {
+                    "name": "DB_USER",
+                    "value": "etherpad"
                   }
                 ],
                 "resources": {}
@@ -145,31 +117,92 @@
       "status": {}
     },
     {
-      "kind": "Service",
-      "apiVersion": "v1",
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "etherpad",
-        "creationTimestamp": null,
-        "labels": {
-          "service": "etherpad"
-        }
+        "name": "mariadb",
+        "creationTimestamp": null
       },
       "spec": {
-        "ports": [
-          {
-            "name": "80",
-            "protocol": "TCP",
-            "port": 80,
-            "targetPort": 9001
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "mariadb"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "mariadb-claim0",
+                "persistentVolumeClaim": {
+                  "claimName": "mariadb-claim0"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": "centos/mariadb",
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "etherpad"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "mariadb-claim0",
+                    "mountPath": "/var/lib/mysql"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
           }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb-claim0",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
         ],
-        "selector": {
-          "service": "etherpad"
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
         }
       },
-      "status": {
-        "loadBalancer": {}
-      }
+      "status": {}
     }
   ]
 }

--- a/script/test/fixtures/etherpad/output-os.json
+++ b/script/test/fixtures/etherpad/output-os.json
@@ -7,33 +7,6 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mariadb",
-        "creationTimestamp": null,
-        "labels": {
-          "service": "mariadb"
-        }
-      },
-      "spec": {
-        "ports": [
-          {
-            "name": "3306",
-            "protocol": "TCP",
-            "port": 3306,
-            "targetPort": 3306
-          }
-        ],
-        "selector": {
-          "service": "mariadb"
-        }
-      },
-      "status": {
-        "loadBalancer": {}
-      }
-    },
-    {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "etherpad",
         "creationTimestamp": null,
         "labels": {
@@ -58,7 +31,7 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
+      "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
         "name": "mariadb",
@@ -68,100 +41,20 @@
         }
       },
       "spec": {
-        "strategy": {
-          "resources": {}
-        },
-        "triggers": [
+        "ports": [
           {
-            "type": "ConfigChange"
-          },
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "mariadb"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "mariadb:latest"
-              }
-            }
+            "name": "3306",
+            "protocol": "TCP",
+            "port": 3306,
+            "targetPort": 3306
           }
         ],
-        "replicas": 1,
-        "test": false,
         "selector": {
           "service": "mariadb"
-        },
-        "template": {
-          "metadata": {
-            "creationTimestamp": null,
-            "labels": {
-              "service": "mariadb"
-            }
-          },
-          "spec": {
-            "containers": [
-              {
-                "name": "mariadb",
-                "image": " ",
-                "ports": [
-                  {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
-                  }
-                ],
-                "env": [
-                  {
-                    "name": "MYSQL_DATABASE",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_PASSWORD",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "etherpad"
-                  },
-                  {
-                    "name": "MYSQL_USER",
-                    "value": "etherpad"
-                  }
-                ],
-                "resources": {}
-              }
-            ],
-            "restartPolicy": "Always"
-          }
         }
       },
-      "status": {}
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "mariadb",
-        "creationTimestamp": null
-      },
-      "spec": {
-        "tags": [
-          {
-            "name": "latest",
-            "annotations": null,
-            "from": {
-              "kind": "DockerImage",
-              "name": "centos/mariadb"
-            },
-            "generation": null,
-            "importPolicy": {}
-          }
-        ]
-      },
       "status": {
-        "dockerImageRepository": ""
+        "loadBalancer": {}
       }
     },
     {
@@ -221,6 +114,10 @@
                 ],
                 "env": [
                   {
+                    "name": "DB_PORT",
+                    "value": "3306"
+                  },
+                  {
                     "name": "DB_USER",
                     "value": "etherpad"
                   },
@@ -235,10 +132,6 @@
                   {
                     "name": "DB_PASS",
                     "value": "etherpad"
-                  },
-                  {
-                    "name": "DB_PORT",
-                    "value": "3306"
                   }
                 ],
                 "resources": {}
@@ -274,6 +167,146 @@
       "status": {
         "dockerImageRepository": ""
       }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "mariadb"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "mariadb"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "mariadb:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "mariadb"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "mariadb"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "mariadb-claim0",
+                "persistentVolumeClaim": {
+                  "claimName": "mariadb-claim0"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "etherpad"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "etherpad"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "mariadb-claim0",
+                    "mountPath": "/var/lib/mysql"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "centos/mariadb"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb-claim0",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
     }
   ]
 }


### PR DESCRIPTION
Volume constraint is missing in mariadb service in etherpad example, so added that so that it mariadb container does not fail in environments where creating container in `/var/lib/mysql` is not allowed for non-root process.