### PR TITLE
added support for cpu_shares

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -35,9 +35,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api/resource"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	"strconv"
 )
 
 /**
@@ -299,6 +301,11 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.Containers[0].WorkingDir = service.WorkingDir
 		template.Spec.Containers[0].VolumeMounts = volumesMount
 		template.Spec.Volumes = volumes
+		cpu, err := resource.ParseQuantity(strconv.FormatInt(service.CPUShares,10))
+		if err != nil {
+			logrus.Error(err)
+		}
+		template.Spec.Containers[0].Resources = api.ResourceRequirements{Limits: api.ResourceList{api.ResourceCPU: cpu}}
 		// Configure the container privileged mode
 		if service.Privileged == true {
 			template.Spec.Containers[0].SecurityContext = &api.SecurityContext{


### PR DESCRIPTION
[WIP] for #267 
How can we convert `cpu_share` defined in [docker](https://docs.docker.com/engine/reference/run/#cpu-share-constraint) to `cpu` defined in [Kubernetes](http://kubernetes.io/docs/user-guide/compute-resources/) as there is no one to one mapping for it. 

**Docker** by default gives all containers get the same proportion of CPU cycles and by using `cpu_share` we can give a percentage of CPU to each container.
 
In **Kubernetes** world, cpu are measured in unit. The expression `0.1` is equivalent to the expression `100m`, which can be read as “one hundred millicpu”. CPU is always requested as an absolute quantity, never as a relative quantity; `0.1` is the same amount of `cpu` on a single core, dual core, or 48 core machine.

Thoughts ? @surajssd @kadel @ngtuna