### PR TITLE
Switch to 'make bin' instead of 'make binary'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - make test-unit
   
   # make test-cmd requires kompose binary
-  - make binary
+  - make bin
   
   # $GOPATH/bin is in $PATH
   - mkdir -p $GOPATH/bin

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,18 @@
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 .PHONY: all
 
 KOMPOSE_ENVS := \
@@ -9,15 +24,15 @@ KOMPOSE_ENVS := \
 
 BIND_DIR := bundles
 
-default: binary
+default: bin
 
-all:
+all: validate
 	CGO_ENABLED=1 ./script/make.sh
 
-binary:
+bin:
 	CGO_ENABLED=1 ./script/make.sh binary
 
-binary-cross:
+cross:
 	# CGO_ENABLED=1 ./script/make.sh binary-cross
 	./script/make.sh binary-cross
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ PROG=kompose source script/bash_autocomplete
 You can either build via the Makefile:
 
 ```console
-$ make binary
+$ make bin
 ```
 
 Or `go build`:
@@ -86,10 +86,10 @@ If you have `go` v1.5, it's still good to build `kompose` with the following set
 $ CGO_ENABLED=0 GO15VENDOREXPERIMENT=1 go build -o kompose main.go
 ```
 
-To create a multi-platform binary, use the `binary-cross` command via `make`:
+To create a multi-platform binary, use the `cross` command via `make`:
 
 ```console
-$ make binary-cross
+$ make cross
 ```
 
 ## Contributing and Issues


### PR DESCRIPTION
I keep mistyping this when creating the binary as per other projects
that use it commonly (it's usually `make bin` instead of `make binary`).