### PR TITLE
Fix container_name incorrectly being generated

### DIFF
--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -88,6 +88,12 @@ func (o *OpenShift) initImageStream(name string, service kobject.ServiceConfig) 
 // initDeploymentConfig initialize OpenShifts DeploymentConfig object
 func (o *OpenShift) initDeploymentConfig(name string, service kobject.ServiceConfig, replicas int) *deployapi.DeploymentConfig {
 	tag := getImageTag(service.Image)
+	containerName := []string{name}
+
+	// Use ContainerName if it was set
+	if service.ContainerName != "" {
+		containerName = []string{service.ContainerName}
+	}
 
 	dc := &deployapi.DeploymentConfig{
 		TypeMeta: unversioned.TypeMeta{
@@ -126,7 +132,7 @@ func (o *OpenShift) initDeploymentConfig(name string, service kobject.ServiceCon
 					ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 						//Automatic - if new tag is detected - update image update inside the pod template
 						Automatic:      true,
-						ContainerNames: []string{name},
+						ContainerNames: containerName,
 						From: api.ObjectReference{
 							Name: name + ":" + tag,
 							Kind: "ImageStreamTag",

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"github.com/kubernetes-incubator/kompose/pkg/kobject"
+	"k8s.io/kubernetes/pkg/api"
+	"testing"
+)
+
+func newServiceConfig() kobject.ServiceConfig {
+	return kobject.ServiceConfig{
+		ContainerName: "myfoobarname",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolTCP}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		Volumes:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		Labels:        nil,
+		Annotations:   map[string]string{"abc": "def"},
+		CPUSet:        "cpu_set",            // not supported
+		CPUShares:     1,                    // not supported
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "user", // not supported
+	}
+}
+
+func TestInitDeploymentConfig(t *testing.T) {
+	o := OpenShift{}
+	spec := o.initDeploymentConfig("foobar", newServiceConfig(), 1)
+
+	// Check that "foobar" is used correctly as a name
+	if spec.Spec.Template.Spec.Containers[0].Name != "foobar" {
+		t.Errorf("Expected foobar for name, actual %s", spec.Spec.Template.Spec.Containers[0].Name)
+	}
+
+	// Check that "myfoobarname" is used correctly as a ContainerName
+	if spec.Spec.Triggers[1].ImageChangeParams.ContainerNames[0] != "myfoobarname" {
+		t.Errorf("Expected myfoobarname for name, actual %s", spec.Spec.Triggers[1].ImageChangeParams.ContainerNames[0])
+	}
+}


### PR DESCRIPTION
Checks to see if "container_name" is used correctly in a docker-compose
file conversion and updates the changes respectively in the outputted
artifact files.

For example with container_name set as myfoobarname, the change will
correctly update the "containerNames" portion of the deployment-config
for OpenShift.

"imageChangeParams": {
  "automatic": true,
  "containerNames": [
    "myfoobarname"
  ],
  "from": {
    "kind": "ImageStreamTag",
    "name": "rabbit:3.6.1"
  }
}

Closes https://github.com/kubernetes-incubator/kompose/issues/301