### PR TITLE
support for raw pod output without controller

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -306,3 +306,27 @@ services:
     labels: 
       kompose.service.type: nodeport
 ```
+
+## Restart
+
+If you want to create normal pods without controllers you can use `restart` construct of docker-compose to define that. Follow table below to see what heppens on the `restart` value.
+
+| `docker-compose` `restart` | object created    | Pod `restartPolicy` |
+|----------------------------|-------------------|---------------------|
+| `""`                       | controller object | `Always`            |
+| `always`                   | controller object | `Always`            |
+| `on-failure`               | Pod               | `OnFailure`         |
+| `no`                       | Pod               | `Never`             |
+
+**Note**: controller object could be `deployment` or `replicationcontroller`, etc.
+
+For e.g. `mariadb` service will become pod down here.
+
+```yaml
+version: "2"
+
+services:
+  mariadb:
+    image: centos/mariadb
+    restart: "no"
+```

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -185,6 +185,8 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 				file = transformer.Print(t.Name, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
 			case *api.PersistentVolumeClaim:
 				file = transformer.Print(t.Name, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+			case *api.Pod:
+				file = transformer.Print(t.Name, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
 			}
 			files = append(files, file)
 		}

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -152,20 +152,27 @@ func (o *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 	var allobjects []runtime.Object
 
 	for name, service := range komposeObject.ServiceConfigs {
-		objects := o.CreateKubernetesObjects(name, service, opt)
+		var objects []runtime.Object
 
-		if opt.CreateDeploymentConfig {
-			objects = append(objects, o.initDeploymentConfig(name, service, opt.Replicas)) // OpenShift DeploymentConfigs
-			// create ImageStream after deployment (creating IS will trigger new deployment)
-			objects = append(objects, o.initImageStream(name, service))
+		// Generate pod only and nothing more
+		if service.Restart == "no" || service.Restart == "on-failure" {
+			pod := o.InitPod(name, service)
+			objects = append(objects, pod)
+		} else {
+			objects = o.CreateKubernetesObjects(name, service, opt)
+
+			if opt.CreateDeploymentConfig {
+				objects = append(objects, o.initDeploymentConfig(name, service, opt.Replicas)) // OpenShift DeploymentConfigs
+				// create ImageStream after deployment (creating IS will trigger new deployment)
+				objects = append(objects, o.initImageStream(name, service))
+			}
+
+			// If ports not provided in configuration we will not make service
+			if o.PortsExist(name, service) {
+				svc := o.CreateService(name, service, objects)
+				objects = append(objects, svc)
+			}
 		}
-
-		// If ports not provided in configuration we will not make service
-		if o.PortsExist(name, service) {
-			svc := o.CreateService(name, service, objects)
-			objects = append(objects, svc)
-		}
-
 		o.UpdateKubernetesObjects(name, service, &objects)
 
 		allobjects = append(allobjects, objects...)

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -103,4 +103,14 @@ convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bun
 # Test related to kompose --bundle convert to ensure that DSB bundles are converted properly
 convert::expect_success_and_warning "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/docker-voting-bundle.dsb convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/output-k8s.json" "Service cannot be created because of missing port."
 
+
+######
+# Test related to restart options in docker-compose
+# kubernetes test
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-no.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-onfail.json"
+# openshift test
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml --provider openshift convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-no.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml --provider openshift convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-onfail.json"
+
 exit $EXIT_STATUS

--- a/script/test/fixtures/restart-options/docker-compose-restart-no.yml
+++ b/script/test/fixtures/restart-options/docker-compose-restart-no.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  foo:
+    image: "foobar"
+    restart: "no"
+    environment:
+      GITHUB: surajssd
+

--- a/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml
+++ b/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  foo:
+    image: "foobar"
+    restart: "on-failure"
+    environment:
+      GITHUB: surajssd
+

--- a/script/test/fixtures/restart-options/output-k8s-restart-no.json
+++ b/script/test/fixtures/restart-options/output-k8s-restart-no.json
@@ -1,0 +1,35 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "foo",
+            "image": "foobar",
+            "env": [
+              {
+                "name": "GITHUB",
+                "value": "surajssd"
+              }
+            ],
+            "resources": {}
+          }
+        ],
+        "restartPolicy": "Never"
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/restart-options/output-k8s-restart-onfail.json
+++ b/script/test/fixtures/restart-options/output-k8s-restart-onfail.json
@@ -1,0 +1,35 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "foo",
+            "image": "foobar",
+            "env": [
+              {
+                "name": "GITHUB",
+                "value": "surajssd"
+              }
+            ],
+            "resources": {}
+          }
+        ],
+        "restartPolicy": "OnFailure"
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/restart-options/output-os-restart-no.json
+++ b/script/test/fixtures/restart-options/output-os-restart-no.json
@@ -1,0 +1,35 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "foo",
+            "image": "foobar",
+            "env": [
+              {
+                "name": "GITHUB",
+                "value": "surajssd"
+              }
+            ],
+            "resources": {}
+          }
+        ],
+        "restartPolicy": "Never"
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/restart-options/output-os-restart-onfail.json
+++ b/script/test/fixtures/restart-options/output-os-restart-onfail.json
@@ -1,0 +1,35 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "foo",
+            "image": "foobar",
+            "env": [
+              {
+                "name": "GITHUB",
+                "value": "surajssd"
+              }
+            ],
+            "resources": {}
+          }
+        ],
+        "restartPolicy": "OnFailure"
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
if a user specifies a docker-compose service with restart value as "no" or "on-failure" then normal pod will be created as against to a controller and a pod.