### PR TITLE
make YAML the default kompose conversion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ If you have a Docker Compose [`docker-compose.yml`](./examples/docker-compose.ym
 ```console
 $ kompose --bundle docker-compose-bundle.dab convert
 WARN[0000]: Unsupported key networks - ignoring
-file "redis-svc.json" created
-file "web-svc.json" created
-file "web-deployment.json" created
-file "redis-deployment.json" created
+file "redis-svc.yaml" created
+file "web-svc.yaml" created
+file "web-deployment.yaml" created
+file "redis-deployment.yaml" created
 
 $ kompose -f docker-compose.yml convert
 WARN[0000]: Unsupported key networks - ignoring
-file "redis-svc.json" created
-file "web-svc.json" created
-file "web-deployment.json" created
-file "redis-deployment.json" created
+file "redis-svc.yaml" created
+file "web-svc.yaml" created
+file "web-deployment.yaml" created
+file "redis-deployment.yaml" created
 ```
 
 Other examples are provided in the _examples_ [directory](./examples).

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -26,12 +26,12 @@ import (
 )
 
 var (
-	ConvertSource, ConvertOut, ConvertBuildRepo, ConvertBuildBranch string
-	ConvertChart, ConvertDeployment, ConvertDaemonSet               bool
-	ConvertReplicationController, ConvertYaml, ConvertStdout        bool
-	ConvertEmptyVols, ConvertDeploymentConfig, ConvertBuildConfig   bool
-	ConvertReplicas                                                 int
-	ConvertOpt                                                      kobject.ConvertOptions
+	ConvertSource, ConvertOut, ConvertBuildRepo, ConvertBuildBranch       string
+	ConvertChart, ConvertDeployment, ConvertDaemonSet                     bool
+	ConvertReplicationController, ConvertYaml, ConvertStdout, ConvertJson bool
+	ConvertEmptyVols, ConvertDeploymentConfig, ConvertBuildConfig         bool
+	ConvertReplicas                                                       int
+	ConvertOpt                                                            kobject.ConvertOptions
 )
 
 var ConvertProvider string = GlobalProvider
@@ -46,6 +46,7 @@ var convertCmd = &cobra.Command{
 			ToStdout:               ConvertStdout,
 			CreateChart:            ConvertChart,
 			GenerateYaml:           ConvertYaml,
+			GenerateJson:           ConvertJson,
 			Replicas:               ConvertReplicas,
 			InputFiles:             GlobalFiles,
 			OutFile:                ConvertOut,
@@ -92,7 +93,10 @@ func init() {
 	convertCmd.Flags().MarkHidden("build-branch")
 
 	// Standard between the two
-	convertCmd.Flags().BoolVarP(&ConvertYaml, "yaml", "y", false, "Generate resource files into yaml format")
+	convertCmd.Flags().BoolVarP(&ConvertYaml, "yaml", "y", false, "Generate resource files into YAML format")
+	convertCmd.Flags().MarkDeprecated("yaml", "YAML is the default format now.")
+	convertCmd.Flags().MarkShorthandDeprecated("y", "YAML is the default format now.")
+	convertCmd.Flags().BoolVarP(&ConvertJson, "json", "j", false, "Generate resource files into JSON format")
 	convertCmd.Flags().BoolVar(&ConvertStdout, "stdout", false, "Print converted objects to stdout")
 	convertCmd.Flags().BoolVar(&ConvertEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")
 	convertCmd.Flags().StringVarP(&ConvertOut, "out", "o", "", "Specify a file name to save objects to")

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -27,7 +27,7 @@ $ cd examples/
 $ ls
 docker-compose.yml  docker-compose-bundle.dab  docker-gitlab.yml  docker-voting.yml
 
-$ kompose -f docker-gitlab.yml convert -y
+$ kompose -f docker-gitlab.yml convert
 file "redisio-svc.yaml" created
 file "gitlab-svc.yaml" created
 file "postgresql-svc.yaml" created
@@ -46,43 +46,43 @@ You can try with a Docker Compose version 2 like this:
 $ kompose --file docker-voting.yml convert
 WARN[0000]: Unsupported key networks - ignoring
 WARN[0000]: Unsupported key build - ignoring
-file "worker-svc.json" created
-file "db-svc.json" created
-file "redis-svc.json" created
-file "result-svc.json" created
-file "vote-svc.json" created
-file "redis-deployment.json" created
-file "result-deployment.json" created
-file "vote-deployment.json" created
-file "worker-deployment.json" created
-file "db-deployment.json" created
+file "worker-svc.yaml" created
+file "db-svc.yaml" created
+file "redis-svc.yaml" created
+file "result-svc.yaml" created
+file "vote-svc.yaml" created
+file "redis-deployment.yaml" created
+file "result-deployment.yaml" created
+file "vote-deployment.yaml" created
+file "worker-deployment.yaml" created
+file "db-deployment.yaml" created
 
 $ ls
-db-deployment.json  docker-compose.yml         docker-gitlab.yml  redis-deployment.json  result-deployment.json  vote-deployment.json  worker-deployment.json
-db-svc.json         docker-compose-bundle.dab  docker-voting.yml  redis-svc.json         result-svc.json         vote-svc.json         worker-svc.json
+db-deployment.yaml  docker-compose.yml         docker-gitlab.yml  redis-deployment.yaml  result-deployment.yaml  vote-deployment.yaml  worker-deployment.yaml
+db-svc.yaml         docker-compose-bundle.dab  docker-voting.yml  redis-svc.yaml         result-svc.yaml         vote-svc.yaml         worker-svc.yaml
 ```
 
 You can also provide multiple docker-compose files at the same time:
 
 ```console
 $ kompose -f docker-compose.yml -f docker-guestbook.yml convert
-file "frontend-service.json" created         
-file "mlbparks-service.json" created         
-file "mongodb-service.json" created          
-file "redis-master-service.json" created     
-file "redis-slave-service.json" created      
-file "frontend-deployment.json" created      
-file "mlbparks-deployment.json" created      
-file "mongodb-deployment.json" created       
-file "mongodb-claim0-persistentvolumeclaim.json" created 
-file "redis-master-deployment.json" created  
-file "redis-slave-deployment.json" created   
+file "frontend-service.yaml" created         
+file "mlbparks-service.yaml" created         
+file "mongodb-service.yaml" created          
+file "redis-master-service.yaml" created     
+file "redis-slave-service.yaml" created      
+file "frontend-deployment.yaml" created      
+file "mlbparks-deployment.yaml" created      
+file "mongodb-deployment.yaml" created       
+file "mongodb-claim0-persistentvolumeclaim.yaml" created 
+file "redis-master-deployment.yaml" created  
+file "redis-slave-deployment.yaml" created   
 
 $ ls
-mlbparks-deployment.json  mongodb-service.json                       redis-slave-service.jsonmlbparks-service.json  
-frontend-deployment.json  mongodb-claim0-persistentvolumeclaim.json  redis-master-service.json
-frontend-service.json     mongodb-deployment.json                    redis-slave-deployment.json
-redis-master-deployment.json
+mlbparks-deployment.yaml  mongodb-service.yaml                       redis-slave-service.jsonmlbparks-service.yaml  
+frontend-deployment.yaml  mongodb-claim0-persistentvolumeclaim.yaml  redis-master-service.yaml
+frontend-service.yaml     mongodb-deployment.yaml                    redis-slave-deployment.yaml
+redis-master-deployment.yaml
 ``` 
 
 When multiple docker-compose files are provided the configuration is merged. Any configuration that is common will be over ridden by subsequent file.
@@ -92,10 +92,10 @@ Using `--bundle, --dab` to specify a DAB file as below:
 ```console
 $ kompose --bundle docker-compose-bundle.dab convert
 WARN[0000]: Unsupported key networks - ignoring
-file "redis-svc.json" created
-file "web-svc.json" created
-file "web-deployment.json" created
-file "redis-deployment.json" created
+file "redis-svc.yaml" created
+file "web-svc.yaml" created
+file "web-deployment.yaml" created
+file "redis-deployment.yaml" created
 ```
 
 ### OpenShift
@@ -103,32 +103,32 @@ file "redis-deployment.json" created
 ```console
 $ kompose --provider openshift --file docker-voting.yml convert
 WARN[0000] [worker] Service cannot be created because of missing port.
-INFO[0000] file "vote-service.json" created             
-INFO[0000] file "db-service.json" created               
-INFO[0000] file "redis-service.json" created            
-INFO[0000] file "result-service.json" created           
-INFO[0000] file "vote-deploymentconfig.json" created    
-INFO[0000] file "vote-imagestream.json" created         
-INFO[0000] file "worker-deploymentconfig.json" created  
-INFO[0000] file "worker-imagestream.json" created       
-INFO[0000] file "db-deploymentconfig.json" created      
-INFO[0000] file "db-imagestream.json" created           
-INFO[0000] file "redis-deploymentconfig.json" created   
-INFO[0000] file "redis-imagestream.json" created        
-INFO[0000] file "result-deploymentconfig.json" created  
-INFO[0000] file "result-imagestream.json" created  
+INFO[0000] file "vote-service.yaml" created             
+INFO[0000] file "db-service.yaml" created               
+INFO[0000] file "redis-service.yaml" created            
+INFO[0000] file "result-service.yaml" created           
+INFO[0000] file "vote-deploymentconfig.yaml" created    
+INFO[0000] file "vote-imagestream.yaml" created         
+INFO[0000] file "worker-deploymentconfig.yaml" created  
+INFO[0000] file "worker-imagestream.yaml" created       
+INFO[0000] file "db-deploymentconfig.yaml" created      
+INFO[0000] file "db-imagestream.yaml" created           
+INFO[0000] file "redis-deploymentconfig.yaml" created   
+INFO[0000] file "redis-imagestream.yaml" created        
+INFO[0000] file "result-deploymentconfig.yaml" created  
+INFO[0000] file "result-imagestream.yaml" created  
 ```
 
 In similar way you can convert DAB files to OpenShift.
 ```console
 $ kompose --bundle docker-compose-bundle.dab --provider openshift convert
 WARN[0000]: Unsupported key networks - ignoring
-INFO[0000] file "redis-svc.json" created
-INFO[0000] file "web-svc.json" created
-INFO[0000] file "web-deploymentconfig.json" created
-INFO[0000] file "web-imagestream.json" created           
-INFO[0000] file "redis-deploymentconfig.json" created
-INFO[0000] file "redis-imagestream.json" created
+INFO[0000] file "redis-svc.yaml" created
+INFO[0000] file "web-svc.yaml" created
+INFO[0000] file "web-deploymentconfig.yaml" created
+INFO[0000] file "web-imagestream.yaml" created           
+INFO[0000] file "redis-deploymentconfig.yaml" created
+INFO[0000] file "redis-imagestream.yaml" created
 ```
 
 It also supports creating buildconfig for build directive in a service. By default, it uses the remote repo for the current git branch as the source repo, and the current branch as the source branch for the build. You can specify a different source repo and branch using ``--build-repo`` and ``--build-branch`` options respectively.
@@ -137,9 +137,9 @@ It also supports creating buildconfig for build directive in a service. By defau
 kompose --provider openshift --file buildconfig/docker-compose.yml convert
 WARN[0000] [foo] Service cannot be created because of missing port. 
 INFO[0000] Buildconfig using git@github.com:rtnpro/kompose.git::master as source. 
-INFO[0000] file "foo-deploymentconfig.json" created     
-INFO[0000] file "foo-imagestream.json" created          
-INFO[0000] file "foo-buildconfig.json" created 
+INFO[0000] file "foo-deploymentconfig.yaml" created     
+INFO[0000] file "foo-imagestream.yaml" created          
+INFO[0000] file "foo-buildconfig.yaml" created 
 ```
 
 **Note**: If you are manually pushing the Openshift artifacts using ``oc create -f``, you need to ensure that you push the imagestream artifact before the buildconfig artifact, to workaround this Openshift issue: https://github.com/openshift/origin/issues/4518 .
@@ -237,10 +237,10 @@ Note:
 
 ## Alternate formats
 
-The default `kompose` transformation will generate Kubernetes [Deployments](http://kubernetes.io/docs/user-guide/deployments/) and [Services](http://kubernetes.io/docs/user-guide/services/), in json format. You have alternative option to generate yaml with `-y`. Also, you can alternatively generate [Replication Controllers](http://kubernetes.io/docs/user-guide/replication-controller/) objects, [Deamon Sets](http://kubernetes.io/docs/admin/daemons/), or [Helm](https://github.com/helm/helm) charts.
+The default `kompose` transformation will generate Kubernetes [Deployments](http://kubernetes.io/docs/user-guide/deployments/) and [Services](http://kubernetes.io/docs/user-guide/services/), in yaml format. You have alternative option to generate json with `-j`. Also, you can alternatively generate [Replication Controllers](http://kubernetes.io/docs/user-guide/replication-controller/) objects, [Deamon Sets](http://kubernetes.io/docs/admin/daemons/), or [Helm](https://github.com/helm/helm) charts.
 
 ```console
-$ kompose convert
+$ kompose convert -j
 file "redis-svc.json" created
 file "web-svc.json" created
 file "redis-deployment.json" created
@@ -249,17 +249,17 @@ file "web-deployment.json" created
 The `*-deployment.json` files contain the Deployment objects.
 
 ```console
-$ kompose convert --rc -y
+$ kompose convert --rc 
 file "redis-svc.yaml" created
 file "web-svc.yaml" created
 file "redis-rc.yaml" created
 file "web-rc.yaml" created
 ```
 
-The `*-rc.yaml` files contain the Replication Controller objects. If you want to specify replicas (default is 1), use `--replicas` flag: `$ kompose convert --rc --replicas 3 -y`
+The `*-rc.yaml` files contain the Replication Controller objects. If you want to specify replicas (default is 1), use `--replicas` flag: `$ kompose convert --rc --replicas 3`
 
 ```console
-$ kompose convert --ds -y
+$ kompose convert --ds 
 file "redis-svc.yaml" created
 file "web-svc.yaml" created
 file "redis-daemonset.yaml" created
@@ -271,7 +271,7 @@ The `*-daemonset.yaml` files contain the Daemon Set objects
 If you want to generate a Chart to be used with [Helm](https://github.com/kubernetes/helm) simply do:
 
 ```console
-$ kompose convert -c -y
+$ kompose convert -c 
 file "web-svc.yaml" created
 file "redis-svc.yaml" created
 file "web-deployment.yaml" created

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -124,6 +124,10 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 	if len(args) != 0 {
 		logrus.Fatal("Unknown Argument(s): ", strings.Join(args, ","))
 	}
+
+	if opt.GenerateJson && opt.GenerateYaml {
+		logrus.Fatalf("YAML and JSON format cannot be provided at the same time")
+	}
 }
 
 func validateControllers(opt *kobject.ConvertOptions) {

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -37,6 +37,7 @@ type ConvertOptions struct {
 	BuildBranch            string
 	CreateChart            bool
 	GenerateYaml           bool
+	GenerateJson           bool
 	EmptyVols              bool
 	Replicas               int
 	InputFiles             []string

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -186,11 +186,11 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 		if err != nil {
 			return err
 		}
-		data, err := marshal(convertedList, opt.GenerateYaml)
+		data, err := marshal(convertedList, opt.GenerateJson)
 		if err != nil {
 			return fmt.Errorf("Error in marshalling the List: %v", err)
 		}
-		files = append(files, transformer.Print("", dirName, "", data, opt.ToStdout, opt.GenerateYaml, f))
+		files = append(files, transformer.Print("", dirName, "", data, opt.ToStdout, opt.GenerateJson, f))
 	} else {
 		var file string
 		// create a separate file for each provider
@@ -199,34 +199,34 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 			if err != nil {
 				return err
 			}
-
-			data, err := marshal(versionedObject, opt.GenerateYaml)
+			data, err := marshal(versionedObject, opt.GenerateJson)
 			if err != nil {
 				return err
 			}
 			switch t := v.(type) {
 			case *api.ReplicationController:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *extensions.Deployment:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *extensions.DaemonSet:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *deployapi.DeploymentConfig:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *buildapi.BuildConfig:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *imageapi.ImageStream:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *api.Service:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *api.PersistentVolumeClaim:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *api.Pod:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *routeapi.Route:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
 			case *extensions.Ingress:
-				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateYaml, f)
+				file = transformer.Print(t.Name, dirName, strings.ToLower(t.Kind), data, opt.ToStdout, opt.GenerateJson, f)
+
 			}
 			files = append(files, file)
 		}
@@ -238,12 +238,12 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 }
 
 // marshal object runtime.Object and return byte array
-func marshal(obj runtime.Object, yamlFormat bool) (data []byte, err error) {
+func marshal(obj runtime.Object, jsonFormat bool) (data []byte, err error) {
 	// convert data to yaml or json
-	if yamlFormat {
-		data, err = yaml.Marshal(obj)
-	} else {
+	if jsonFormat {
 		data, err = json.MarshalIndent(obj, "", "  ")
+	} else {
+		data, err = yaml.Marshal(obj)
 	}
 	if err != nil {
 		data = nil

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -110,7 +110,7 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 }
 
 // Transform data to json/yaml
-func TransformData(obj runtime.Object, GenerateYaml bool) ([]byte, error) {
+func TransformData(obj runtime.Object, GenerateJson bool) ([]byte, error) {
 	//  Convert to versioned object
 	objectVersion := obj.GetObjectKind().GroupVersionKind()
 	version := unversioned.GroupVersion{Group: objectVersion.Group, Version: objectVersion.Version}
@@ -120,9 +120,9 @@ func TransformData(obj runtime.Object, GenerateYaml bool) ([]byte, error) {
 	}
 
 	// convert data to json / yaml
-	data, err := json.MarshalIndent(versionedObj, "", "  ")
-	if GenerateYaml == true {
-		data, err = yaml.Marshal(versionedObj)
+	data, err := yaml.Marshal(versionedObj)
+	if GenerateJson == true {
+		data, err = json.MarshalIndent(versionedObj, "", "  ")
 	}
 	if err != nil {
 		return nil, err
@@ -132,13 +132,13 @@ func TransformData(obj runtime.Object, GenerateYaml bool) ([]byte, error) {
 }
 
 // Either print to stdout or to file/s
-func Print(name, path string, trailing string, data []byte, toStdout, generateYaml bool, f *os.File) string {
+func Print(name, path string, trailing string, data []byte, toStdout, generateJson bool, f *os.File) string {
 
 	file := ""
-	if generateYaml {
-		file = fmt.Sprintf("%s-%s.yaml", name, trailing)
-	} else {
+	if generateJson {
 		file = fmt.Sprintf("%s-%s.json", name, trailing)
+	} else {
+		file = fmt.Sprintf("%s-%s.yaml", name, trailing)
 	}
 	if toStdout {
 		fmt.Fprintf(os.Stdout, "%s\n", string(data))

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -26,153 +26,153 @@ convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/
 convert::expect_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose-no-ports.yml convert --stdout" "Service cannot be created because of missing port."
 export $(cat $KOMPOSE_ROOT/script/test/fixtures/etherpad/envs)
 # kubernetes test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-k8s.json" "Unsupported depends_on key - ignoring"
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-k8s.json" "Unsupported depends_on key - ignoring"
 # openshift test
-convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-os.json" "Unsupported depends_on key - ignoring"
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-os.json" "Unsupported depends_on key - ignoring"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/etherpad/envs | cut -d'=' -f1)
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/gitlab
-convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout"
+convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout -j"
 export $(cat $KOMPOSE_ROOT/script/test/fixtures/gitlab/envs)
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-k8s.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-k8s.json"
 # openshift test
-convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-os.json"
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-os.json"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/gitlab/envs | cut -d'=' -f1)
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/ngnix-node-redis
 # kubernetes test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-k8s.json" "Kubernetes provider doesn't support build key - ignoring"
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-k8s.json" "Kubernetes provider doesn't support build key - ignoring"
 # openshift test
-convert::expect_success_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-os.json" "Buildconfig using https://github.com/kubernetes-incubator/kompose.git::master as source."
+convert::expect_success_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-os.json" "Buildconfig using https://github.com/kubernetes-incubator/kompose.git::master as source."
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/entrypoint-command
 # kubernetes test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-k8s.json" "Service cannot be created because of missing port."
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-k8s.json" "Service cannot be created because of missing port."
 # openshift test
-convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-os.json" "Service cannot be created because of missing port."
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-os.json" "Service cannot be created because of missing port."
 
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/ports-with-proto
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-k8s.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-k8s.json"
 # openshift test
-convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-os.json"
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-os.json"
 
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/volume-mounts/simple-vol-mounts
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s.json"
 # openshift test
-convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/output-os.json"
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/output-os.json"
 
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/volume-mounts/volumes-from
 # kubernetes test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/output-k8s.json" "ignoring path on the host"
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/output-k8s.json" "ignoring path on the host"
 # openshift test
-convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/output-os.json" "ignoring path on the host"
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/output-os.json" "ignoring path on the host"
 
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/envvars-separators
 # kubernetes test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/envvars-separators/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/envvars-separators/output-k8s.json"
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/envvars-separators/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/envvars-separators/output-k8s.json"
 
 ######
 # Tests related to unknown arguments with cli commands
-convert::expect_failure "kompose up $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml" "Unknown Argument docker-gitlab.yml"
-convert::expect_failure "kompose down $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml" "Unknown Argument docker-gitlab.yml"
-convert::expect_failure "kompose convert $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml" "Unknown Argument docker-gitlab.yml"
+convert::expect_failure "kompose up $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml -j" "Unknown Argument docker-gitlab.yml"
+convert::expect_failure "kompose down $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml -j" "Unknown Argument docker-gitlab.yml"
+convert::expect_failure "kompose convert $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml -j" "Unknown Argument docker-gitlab.yml"
 
 # Tests related to kompose --bundle convert usage and that setting the compose file results in a failure
 convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/bundles/foo.yml --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert"
 
 ######
 # Test related to kompose --bundle convert to ensure that docker bundles are converted properly
-convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dab/output-k8s.json"
+convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dab/output-k8s.json"
 
 # Test related to multiple-compose files
 # Kubernets test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-k8s.json" "Unsupported depends_on key - ignoring"
-convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-openshift.json" "Unsupported depends_on key - ignoring"
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-k8s.json" "Unsupported depends_on key - ignoring"
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-openshift.json" "Unsupported depends_on key - ignoring"
 
 ######
 # Test related to kompose --bundle convert to ensure that DSB bundles are converted properly
-convert::expect_success_and_warning "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/docker-voting-bundle.dsb convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/output-k8s.json" "Service cannot be created because of missing port."
+convert::expect_success_and_warning "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/docker-voting-bundle.dsb convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/output-k8s.json" "Service cannot be created because of missing port."
 
 ######
 # Test related to restart options in docker-compose
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-no.json"
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-onfail.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-no.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-k8s-restart-onfail.json"
 # openshift test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml --provider openshift convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-no.json"
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml --provider openshift convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-onfail.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-no.yml --provider openshift convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-no.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/restart-options/docker-compose-restart-onfail.yml --provider openshift convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/restart-options/output-os-restart-onfail.json"
 
 
 ######
 # Test key-only envrionment variable
 export $(cat $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/envs)
-convert::expect_success "kompose --file $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/env.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/output-k8s.json"
+convert::expect_success "kompose --file $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/env.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/output-k8s.json"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/envs | cut -d'=' -f1)
 
 
 ######
 # Test related to "stdin_open: true" in docker-compose
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-k8s.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-k8s.json"
 # openshift test
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-oc.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-oc.json"
 
 
 ######
 # Test related to "tty: true" in docker-compose
 # kubernetes test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-k8s.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-k8s.json"
 # openshift test
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-oc.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-oc.json"
 
 
 # Test related to kompose.expose.service label in docker compose file to ensure that services are exposed properly
 #kubernetes tests
 # when kompose.service.expose="True"
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json"
 # when kompose.expose.service="<hostname>"
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json"
 # when kompose.service.expose="True" and multiple ports in docker compose file (first port should be selected)
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true-multiple-ports.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json"
 # when kompose.service.expose="<hostname>" and multiple ports in docker compose file (first port should be selected)
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json"
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json"
 
 #openshift tests
 # when kompose.service.expose="True"
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json"
 # when kompose.expose.service="<hostname>"
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json"
 # when kompose.service.expose="True" and multiple ports in docker compose file (first port should be selected)
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true-multiple-ports.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-true-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json"
 # when kompose.service.expose="<hostname>" and multiple ports in docker compose file (first port should be selected)
-convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json"
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json"
 
 
 ######
 # Test the output file behavior of kompose convert
 # Default behavior without -o
-convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert" "" "$TEMP_DIR/redis-deployment.json" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
+convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -j" "" "$TEMP_DIR/redis-deployment.json -j" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
 # Behavior with -o <filename>
-convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_file" "" "$TEMP_DIR/output_file"
+convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_file -j" "" "$TEMP_DIR/output_file"
 # Behavior with -o <dirname>
-convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir" "$TEMP_DIR/output_dir/" "$TEMP_DIR/output_dir/redis-deployment.json" "$TEMP_DIR/output_dir/redis-service.json" "$TEMP_DIR/output_dir/web-deployment.json" "$TEMP_DIR/output_dir/web-service.json"
+convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir -j" "$TEMP_DIR/output_dir/" "$TEMP_DIR/output_dir/redis-deployment.json" "$TEMP_DIR/output_dir/redis-service.json" "$TEMP_DIR/output_dir/web-deployment.json" "$TEMP_DIR/output_dir/web-service.json"
 # Behavior with -o <dirname>/<filename>
-convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir/output_file" "$TEMP_DIR/output_dir/" "$TEMP_DIR/output_dir/output_file"
+convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir/output_file -j" "$TEMP_DIR/output_dir/" "$TEMP_DIR/output_dir/output_file"
 # Behavior with -o <dirname>/<dirname>/<filename>
-convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir/output_dir_nested/output_file" "$TEMP_DIR/output_dir/output_dir_nested" "$TEMP_DIR/output_dir/output_dir_nested/output_file"
+convert::files_exist "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o output_dir/output_dir_nested/output_file -j" "$TEMP_DIR/output_dir/output_dir_nested" "$TEMP_DIR/output_dir/output_dir_nested/output_file"
 
 exit $EXIT_STATUS


### PR DESCRIPTION
FIX #306 

cc @kadel @surajssd 

```bash
$ kompose convert
INFO[0000] file "mlbparks-service.yaml" created         
INFO[0000] file "mongodb-service.yaml" created          
INFO[0000] file "mlbparks-deployment.yaml" created      
INFO[0000] file "mongodb-deployment.yaml" created       
INFO[0000] file "mongodb-claim0-persistentvolumeclaim.yaml" created 
```

```bash
$ kompose convert -j
INFO[0000] file "mlbparks-service.json" created         
INFO[0000] file "mongodb-service.json" created          
INFO[0000] file "mlbparks-deployment.json" created      
INFO[0000] file "mongodb-deployment.json" created       
INFO[0000] file "mongodb-claim0-persistentvolumeclaim.json" created
```