### PR TITLE
add stdin_open, tty support, add tests, fix #344

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -69,6 +69,8 @@ type ServiceConfig struct {
 	ServiceType   string            `compose:"kompose.service.type",bundle:""`
 	Build         string            `compose:"build",bundle:""`
 	ExposeService string            `compose:"kompose.service.expose",bundle:""`
+	Stdin         bool              `compose:"stdin_open",bundle:""`
+	Tty           bool              `compose:"tty",bundle:""`
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -72,8 +72,6 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 		"VolumeDriver":  false,
 		"Uts":           false,
 		"ReadOnly":      false,
-		"StdinOpen":     false,
-		"Tty":           false,
 		"Ulimits":       false,
 		"Dockerfile":    false,
 		"Net":           false,
@@ -320,6 +318,8 @@ func (c *Compose) LoadFile(file string) kobject.KomposeObject {
 			serviceConfig.Restart = composeServiceConfig.Restart
 			serviceConfig.User = composeServiceConfig.User
 			serviceConfig.VolumesFrom = composeServiceConfig.VolumesFrom
+			serviceConfig.Stdin = composeServiceConfig.StdinOpen
+			serviceConfig.Tty = composeServiceConfig.Tty
 
 			komposeObject.ServiceConfigs[name] = serviceConfig
 		}

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -324,6 +324,8 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.Containers[0].Args = service.Args
 		template.Spec.Containers[0].WorkingDir = service.WorkingDir
 		template.Spec.Containers[0].VolumeMounts = volumesMount
+		template.Spec.Containers[0].Stdin = service.Stdin
+		template.Spec.Containers[0].TTY = service.Tty
 		template.Spec.Volumes = volumes
 
 		securityContext := &api.SecurityContext{}

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -53,6 +53,8 @@ func newServiceConfig() kobject.ServiceConfig {
 		Privileged:    true,
 		Restart:       "always",
 		User:          "user", // not supported
+		Stdin:         true,
+		Tty:           true,
 	}
 }
 
@@ -167,6 +169,12 @@ func checkPodTemplate(config kobject.ServiceConfig, template api.PodTemplateSpec
 	}
 	if config.Privileged == privilegedNilOrFalse(template) {
 		return fmt.Errorf("Found different template privileged: %#v vs. %#v", config.Privileged, template.Spec.Containers[0].SecurityContext)
+	}
+	if config.Stdin != template.Spec.Containers[0].Stdin {
+		return fmt.Errorf("Found different values for stdin: %#v vs. %#v", config.Stdin, template.Spec.Containers[0].Stdin)
+	}
+	if config.Tty != template.Spec.Containers[0].TTY {
+		return fmt.Errorf("Found different values for TTY: %#v vs. %#v", config.Tty, template.Spec.Containers[0].TTY)
 	}
 	return nil
 }

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -119,6 +119,22 @@ convert::expect_success "kompose --file $KOMPOSE_ROOT/script/test/fixtures/keyon
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/envs | cut -d'=' -f1)
 
 
+######
+# Test related to "stdin_open: true" in docker-compose
+# kubernetes test
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-k8s.json"
+# openshift test
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/stdin-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/stdin-true/output-oc.json"
+
+
+######
+# Test related to "tty: true" in docker-compose
+# kubernetes test
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-k8s.json"
+# openshift test
+convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/tty-true/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/tty-true/output-oc.json"
+
+
 # Test related to kompose.expose.service label in docker compose file to ensure that services are exposed properly
 #kubernetes tests
 # when kompose.service.expose="True"

--- a/script/test/fixtures/stdin-true/docker-compose.yml
+++ b/script/test/fixtures/stdin-true/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+  client:
+    image: registry.centos.org/centos/centos:7
+    ports:
+    - "1337"
+    stdin_open: true

--- a/script/test/fixtures/stdin-true/output-k8s.json
+++ b/script/test/fixtures/stdin-true/output-k8s.json
@@ -1,0 +1,72 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "1337",
+            "protocol": "TCP",
+            "port": 1337,
+            "targetPort": 1337
+          }
+        ],
+        "selector": {
+          "service": "client"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "client"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "client",
+                "image": "registry.centos.org/centos/centos:7",
+                "ports": [
+                  {
+                    "containerPort": 1337,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {},
+                "stdin": true
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/stdin-true/output-oc.json
+++ b/script/test/fixtures/stdin-true/output-oc.json
@@ -1,0 +1,124 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "1337",
+            "protocol": "TCP",
+            "port": 1337,
+            "targetPort": 1337
+          }
+        ],
+        "selector": {
+          "service": "client"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "client"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "client:7"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "client"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "client"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "client",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 1337,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {},
+                "stdin": true
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "7",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.centos.org/centos/centos:7"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}

--- a/script/test/fixtures/tty-true/docker-compose.yml
+++ b/script/test/fixtures/tty-true/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+  client:
+    image: registry.centos.org/centos/centos:7
+    ports:
+    - "1337"
+    tty: true

--- a/script/test/fixtures/tty-true/output-k8s.json
+++ b/script/test/fixtures/tty-true/output-k8s.json
@@ -1,0 +1,72 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "1337",
+            "protocol": "TCP",
+            "port": 1337,
+            "targetPort": 1337
+          }
+        ],
+        "selector": {
+          "service": "client"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "client"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "client",
+                "image": "registry.centos.org/centos/centos:7",
+                "ports": [
+                  {
+                    "containerPort": 1337,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {},
+                "tty": true
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/tty-true/output-oc.json
+++ b/script/test/fixtures/tty-true/output-oc.json
@@ -1,0 +1,124 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "1337",
+            "protocol": "TCP",
+            "port": 1337,
+            "targetPort": 1337
+          }
+        ],
+        "selector": {
+          "service": "client"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "client"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "client"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "client:7"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "client"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "client"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "client",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 1337,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {},
+                "tty": true
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "client",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "7",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.centos.org/centos/centos:7"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds supports for stdin_open: bool and
tty: bool support for kubernetes and openshift
providers in kompose. This maps to the
template.Spec.Containers[0].Stdin and
template.Spec.Containers[0].TTY in Kubernets
world.

Also, added tests.

Fixes #344