### PR TITLE
added support for docker-compose.yaml besides docker-compose.yml

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -74,6 +74,7 @@ var convertCmd = &cobra.Command{
 
 		// Validate before doing anything else. Use "bundle" if passed in.
 		app.ValidateFlags(GlobalBundle, args, cmd, &ConvertOpt)
+		app.ValidateComposeFile(cmd, &ConvertOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -44,6 +44,9 @@ var downCmd = &cobra.Command{
 			Provider:   strings.ToLower(GlobalProvider),
 			EmptyVols:  DownEmptyVols,
 		}
+
+		// Validate before doing anything else.
+		app.ValidateComposeFile(cmd, &DownOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app.Down(DownOpt)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -44,6 +44,9 @@ var upCmd = &cobra.Command{
 			Provider:   strings.ToLower(GlobalProvider),
 			EmptyVols:  UpEmptyVols,
 		}
+
+		// Validate before doing anything else.
+		app.ValidateComposeFile(cmd, &UpOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app.Up(UpOpt)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubernetes-incubator/kompose/pkg/transformer"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/kubernetes"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/openshift"
+	"os"
 )
 
 const (
@@ -130,6 +131,23 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 
 	if opt.GenerateJSON && opt.GenerateYaml {
 		logrus.Fatalf("YAML and JSON format cannot be provided at the same time")
+	}
+}
+
+// ValidateComposeFile validated the compose file provided for conversion
+func ValidateComposeFile(cmd *cobra.Command, opt *kobject.ConvertOptions) {
+	if len(opt.InputFiles) == 0 {
+		// Here docker-compose is the input
+		opt.InputFiles = []string{"docker-compose.yml"}
+		_, err := os.Stat("docker-compose.yml")
+		if err != nil {
+			logrus.Debugf("'docker-compose.yml' not found: %v", err)
+			opt.InputFiles = []string{"docker-compose.yaml"}
+			_, err = os.Stat("docker-compose.yaml")
+			if err != nil {
+				logrus.Fatalf("No 'docker-compose' file found: %v", err)
+			}
+		}
 	}
 }
 

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -233,9 +233,6 @@ func (c *Compose) LoadFile(files []string) kobject.KomposeObject {
 		LoadedFrom:     "compose",
 	}
 	context := &project.Context{}
-	if len(files) == 0 {
-		files = append(files, "docker-compose.yml")
-	}
 	context.ComposeFiles = files
 
 	if context.ResourceLookup == nil {

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -101,6 +101,7 @@ convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bun
 # Test related to multiple-compose files
 # Kubernets test
 convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-k8s.json" "Unsupported depends_on key - ignoring"
+# OpenShift test
 convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-openshift.json" "Unsupported depends_on key - ignoring"
 
 ######
@@ -161,7 +162,6 @@ convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/te
 # when kompose.service.expose="<hostname>" and multiple ports in docker compose file (first port should be selected)
 convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json"
 
-
 ######
 # Test the output file behavior of kompose convert
 # Default behavior without -o
@@ -172,5 +172,21 @@ convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/examples/docker-com
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o $TEMP_DIR -j" "$TEMP_DIR/redis-deployment.json" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
 # Behavior with -o <dirname>/<filename>
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/examples/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
+
+# Test related to support docker-compose.yaml beside docker-compose.yml
+# Store the original path
+CURRENT_DIR=$(pwd)
+# Kubernets test
+cd "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/"
+convert::expect_success "kompose convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/output-k8s.json"
+cd "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/yml"
+convert::expect_success "kompose convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/yml/output-k8s.json"
+# OpenShift test
+cd "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/"
+convert::expect_success "kompose --provider=openshift convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/output-os.json"
+cd "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/yml"
+convert::expect_success "kompose --provider=openshift convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/yaml-and-yml/yml/output-os.json"
+# Return back to the original path
+cd $CURRENT_DIR
 
 exit $EXIT_STATUS

--- a/script/test/fixtures/yaml-and-yml/docker-compose.yaml
+++ b/script/test/fixtures/yaml-and-yml/docker-compose.yaml
@@ -1,0 +1,10 @@
+web:
+  image: tuna/docker-counter23
+  ports:
+    - "5000:5000"
+  links:
+    - redis
+redis:
+  image: redis:3.0
+  ports:
+    - "6379"

--- a/script/test/fixtures/yaml-and-yml/output-k8s.json
+++ b/script/test/fixtures/yaml-and-yml/output-k8s.json
@@ -1,0 +1,135 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "protocol": "TCP",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis:3.0",
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "tuna/docker-counter23",
+                "ports": [
+                  {
+                    "containerPort": 5000,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/yaml-and-yml/output-os.json
+++ b/script/test/fixtures/yaml-and-yml/output-os.json
@@ -1,0 +1,239 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "protocol": "TCP",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "redis"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "redis:3.0"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "redis"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "3.0",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis:3.0"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "web"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "web:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "web"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 5000,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "tuna/docker-counter23"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}

--- a/script/test/fixtures/yaml-and-yml/yml/docker-compose.yml
+++ b/script/test/fixtures/yaml-and-yml/yml/docker-compose.yml
@@ -1,0 +1,10 @@
+web:
+  image: tuna/docker-counter23
+  ports:
+    - "5000:5000"
+  links:
+    - redis
+redis:
+  image: redis:3.0
+  ports:
+    - "6379"

--- a/script/test/fixtures/yaml-and-yml/yml/output-k8s.json
+++ b/script/test/fixtures/yaml-and-yml/yml/output-k8s.json
@@ -1,0 +1,135 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "protocol": "TCP",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis:3.0",
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "tuna/docker-counter23",
+                "ports": [
+                  {
+                    "containerPort": 5000,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/yaml-and-yml/yml/output-os.json
+++ b/script/test/fixtures/yaml-and-yml/yml/output-os.json
@@ -1,0 +1,239 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "protocol": "TCP",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "redis"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "redis:3.0"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "redis"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "3.0",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis:3.0"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "web"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "web:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "web"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 5000,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "tuna/docker-counter23"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Now `kompose` will look for `docker-compose.yml` as well as `docker-compose.yaml` in the current directory, when `-f` or `--file` flag in not given .
```console
$ ls
docker-compose.yml
$ kompose convert
INFO[0000] file "mlbparks-service.yaml" created         
INFO[0000] file "mongodb-service.yaml" created          
INFO[0000] file "mlbparks-deployment.yaml" created      
INFO[0000] file "mongodb-deployment.yaml" created       
INFO[0000] file "mongodb-claim0-persistentvolumeclaim.yaml" created
```

```console
$ ls
docker-compose.yaml
$ kompose convert
INFO[0000] file "mlbparks-service.yaml" created         
INFO[0000] file "mongodb-service.yaml" created          
INFO[0000] file "mlbparks-deployment.yaml" created      
INFO[0000] file "mongodb-deployment.yaml" created       
INFO[0000] file "mongodb-claim0-persistentvolumeclaim.yaml" created
```
cc. @containscafeine @surajssd @kadel
Fixes #352 and #369 includes functional tests
I think we can now close #367 