### PR TITLE
Fixed warnings related to user type in tests

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -54,7 +54,6 @@ func TestCreateService(t *testing.T) {
 		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
-		User:          "user",
 	}
 
 	// An example object generated via k8s runtime.Objects()

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -52,7 +52,6 @@ func newServiceConfig() kobject.ServiceConfig {
 		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
-		User:          "user", // not supported
 		Stdin:         true,
 		Tty:           true,
 	}

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -51,7 +51,6 @@ func newServiceConfig() kobject.ServiceConfig {
 		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
-		User:          "user", // not supported
 		Stdin:         true,
 		Tty:           true,
 	}


### PR DESCRIPTION
Fixes #343

Type of user is not string and that's what was being provided
in tests so fixed it and now tests output is cleaner.