### PR TITLE
Ignores :z or :Z when passed in as a volume string

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -321,11 +321,14 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 
 	var count int
 	for _, volume := range service.Volumes {
+
 		volumeName, host, container, mode, err := transformer.ParseVolume(volume)
 		if err != nil {
 			logrus.Warningf("Failed to configure container volume: %v", err)
 			continue
 		}
+
+		logrus.Debug("Volume name %s", volumeName)
 
 		// check if ro/rw mode is defined, default rw
 		readonly := len(mode) > 0 && mode == "ro"

--- a/pkg/transformer/utils_test.go
+++ b/pkg/transformer/utils_test.go
@@ -21,6 +21,18 @@ import (
 	"testing"
 )
 
+// When passing "z" or "Z" we expect "" back.
+func TestZParseVolumeLabeling(t *testing.T) {
+	testCase := "/foobar:/foobar:Z"
+	_, _, _, mode, err := ParseVolume(testCase)
+	if err != nil {
+		t.Errorf("In test case %q, returned unexpected error %v", testCase, err)
+	}
+	if mode != "" {
+		t.Errorf("In test case %q, returned mode %s, expected \"\"", testCase, mode)
+	}
+}
+
 func TestParseVolume(t *testing.T) {
 	name1 := "datavolume"
 	host1 := "./cache"


### PR DESCRIPTION
We're going to ignore :z / :Z for labeling aka SELinux when being passed
in via Docker Compose.

Closes https://github.com/kubernetes-incubator/kompose/issues/176