### PR TITLE
Add support for host:port:port

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -91,5 +91,6 @@ type EnvVar struct {
 type Ports struct {
 	HostPort      int32
 	ContainerPort int32
+	HostIP        string
 	Protocol      api.Protocol
 }

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
+	"k8s.io/kubernetes/pkg/api"
 
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
@@ -49,6 +50,55 @@ func TestHandleServiceType(t *testing.T) {
 		result := handleServiceType(tt.labelValue)
 		if result != tt.serviceType {
 			t.Errorf("Expected %q, got %q", tt.serviceType, result)
+		}
+	}
+}
+
+// Test loading of ports
+func TestLoadPorts(t *testing.T) {
+	port1 := []string{"127.0.0.1:80:80/tcp"}
+	result1 := kobject.Ports{
+		HostIP:        "127.0.0.1",
+		HostPort:      80,
+		ContainerPort: 80,
+		Protocol:      api.ProtocolTCP,
+	}
+	port2 := []string{"80:80/tcp"}
+	result2 := kobject.Ports{
+		HostPort:      80,
+		ContainerPort: 80,
+		Protocol:      api.ProtocolTCP,
+	}
+	port3 := []string{"80:80"}
+	result3 := kobject.Ports{
+		HostPort:      80,
+		ContainerPort: 80,
+		Protocol:      api.ProtocolTCP,
+	}
+	port4 := []string{"80"}
+	result4 := kobject.Ports{
+		HostPort:      0,
+		ContainerPort: 80,
+		Protocol:      api.ProtocolTCP,
+	}
+
+	tests := []struct {
+		ports  []string
+		result kobject.Ports
+	}{
+		{port1, result1},
+		{port2, result2},
+		{port3, result3},
+		{port4, result4},
+	}
+
+	for _, tt := range tests {
+		result, err := loadPorts(tt.ports)
+		if err != nil {
+			t.Errorf("Unexpected error with loading ports %v", err)
+		}
+		if result[0] != tt.result {
+			t.Errorf("Expected %q, got %q", tt.result, result[0])
 		}
 	}
 }

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -285,13 +285,16 @@ func (k *Kubernetes) ConfigPorts(name string, service kobject.ServiceConfig) []a
 		if port.Protocol == api.ProtocolTCP {
 			ports = append(ports, api.ContainerPort{
 				ContainerPort: port.ContainerPort,
+				HostIP:        port.HostIP,
 			})
 		} else {
 			ports = append(ports, api.ContainerPort{
 				ContainerPort: port.ContainerPort,
 				Protocol:      port.Protocol,
+				HostIP:        port.HostIP,
 			})
 		}
+
 	}
 
 	return ports
@@ -304,6 +307,7 @@ func (k *Kubernetes) ConfigServicePorts(name string, service kobject.ServiceConf
 		if port.HostPort == 0 {
 			port.HostPort = port.ContainerPort
 		}
+
 		var targetPort intstr.IntOrString
 		targetPort.IntVal = port.ContainerPort
 		targetPort.StrVal = strconv.Itoa(int(port.ContainerPort))

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -123,6 +123,11 @@ export $(cat $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/envs)
 convert::expect_success "kompose --file $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/env.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/output-k8s.json"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/keyonly-envs/envs | cut -d'=' -f1)
 
+#####
+# Test related to host:port:container in docker-compose
+# kubernetes test
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-ip/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-ip/output-k8s.json"
+
 
 ######
 # Test related to "stdin_open: true" in docker-compose

--- a/script/test/fixtures/ports-with-ip/docker-compose.yml
+++ b/script/test/fixtures/ports-with-ip/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+    web:
+      image: tuna/docker-counter23
+      ports:
+        - "127.0.0.1:5000:5000/tcp"
+      links:
+        - redis
+      networks:
+        - default
+    
+    redis:
+      image: redis:3.0
+      networks: 
+        - default
+      ports:
+        - "6379/tcp"
+        - "1234:1235/udp"

--- a/script/test/fixtures/ports-with-ip/output-k8s.json
+++ b/script/test/fixtures/ports-with-ip/output-k8s.json
@@ -1,0 +1,142 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "redis"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          },
+          {
+            "name": "1234",
+            "protocol": "UDP",
+            "port": 1234,
+            "targetPort": 1235
+          }
+        ],
+        "selector": {
+          "service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis:3.0",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  },
+                  {
+                    "containerPort": 1235,
+                    "protocol": "UDP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "tuna/docker-counter23",
+                "ports": [
+                  {
+                    "containerPort": 5000,
+                    "hostIP": "127.0.0.1"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for supplying for example:
"127.0.0.1:80:80/tcp" to docker-compose.yaml and converting it to it's
corresponding Kubernetes / OpenShift hostIP.

This commit also refactors the loadPorts function of compose.go