### PR TITLE
Removes the TCP output on the Kubernetes / OpenShift artifacts

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -280,10 +280,18 @@ func (k *Kubernetes) CreatePVC(name string, mode string) *api.PersistentVolumeCl
 func (k *Kubernetes) ConfigPorts(name string, service kobject.ServiceConfig) []api.ContainerPort {
 	ports := []api.ContainerPort{}
 	for _, port := range service.Port {
-		ports = append(ports, api.ContainerPort{
-			ContainerPort: port.ContainerPort,
-			Protocol:      port.Protocol,
-		})
+
+		// If the default is already TCP, no need to include it.
+		if port.Protocol == api.ProtocolTCP {
+			ports = append(ports, api.ContainerPort{
+				ContainerPort: port.ContainerPort,
+			})
+		} else {
+			ports = append(ports, api.ContainerPort{
+				ContainerPort: port.ContainerPort,
+				Protocol:      port.Protocol,
+			})
+		}
 	}
 
 	return ports
@@ -299,12 +307,22 @@ func (k *Kubernetes) ConfigServicePorts(name string, service kobject.ServiceConf
 		var targetPort intstr.IntOrString
 		targetPort.IntVal = port.ContainerPort
 		targetPort.StrVal = strconv.Itoa(int(port.ContainerPort))
-		servicePorts = append(servicePorts, api.ServicePort{
-			Name:       strconv.Itoa(int(port.HostPort)),
-			Protocol:   port.Protocol,
-			Port:       port.HostPort,
-			TargetPort: targetPort,
-		})
+
+		// If the default is already TCP, no need to include it.
+		if port.Protocol == api.ProtocolTCP {
+			servicePorts = append(servicePorts, api.ServicePort{
+				Name:       strconv.Itoa(int(port.HostPort)),
+				Port:       port.HostPort,
+				TargetPort: targetPort,
+			})
+		} else {
+			servicePorts = append(servicePorts, api.ServicePort{
+				Name:       strconv.Itoa(int(port.HostPort)),
+				Protocol:   port.Protocol,
+				Port:       port.HostPort,
+				TargetPort: targetPort,
+			})
+		}
 	}
 	return servicePorts
 }

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -36,7 +36,7 @@ func newServiceConfig() kobject.ServiceConfig {
 		ContainerName: "name",
 		Image:         "image",
 		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
-		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolTCP}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456}},
 		Command:       []string{"cmd"},
 		WorkingDir:    "dir",
 		Args:          []string{"arg1", "arg2"},

--- a/script/test/fixtures/bundles/dab/output-k8s.json
+++ b/script/test/fixtures/bundles/dab/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -80,8 +78,7 @@
                 "image": "redis",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -117,8 +114,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/bundles/dsb/output-k8s.json
+++ b/script/test/fixtures/bundles/dsb/output-k8s.json
@@ -47,7 +47,6 @@
         "ports": [
           {
             "name": "5432",
-            "protocol": "TCP",
             "port": 5432,
             "targetPort": 5432
           }
@@ -74,7 +73,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -101,7 +99,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -131,7 +128,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -201,8 +197,7 @@
                 "image": "postgres",
                 "ports": [
                   {
-                    "containerPort": 5432,
-                    "protocol": "TCP"
+                    "containerPort": 5432
                   }
                 ],
                 "resources": {}
@@ -238,8 +233,7 @@
                 "image": "redis",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -275,8 +269,7 @@
                 "image": "tmadams333/example-voting-app-result",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {}
@@ -315,8 +308,7 @@
                 "image": "docker/example-voting-app-vote",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/envvars-separators/output-k8s.json
+++ b/script/test/fixtures/envvars-separators/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "27017",
-            "protocol": "TCP",
             "port": 27017,
             "targetPort": 27017
           }
@@ -260,7 +259,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -341,7 +339,6 @@
         "ports": [
           {
             "name": "8088",
-            "protocol": "TCP",
             "port": 8088,
             "targetPort": 80
           }
@@ -389,8 +386,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 27017,
-                    "protocol": "TCP"
+                    "containerPort": 27017
                   }
                 ],
                 "resources": {},
@@ -985,8 +981,7 @@
                 "image": "hygieia-api:latest",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {},
@@ -1185,8 +1180,7 @@
                 "image": "hygieia-ui:latest",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/etherpad/output-k8s.json
+++ b/script/test/fixtures/etherpad/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "3306",
-            "protocol": "TCP",
             "port": 3306,
             "targetPort": 3306
           }
@@ -80,8 +78,7 @@
                 "image": "centos/etherpad",
                 "ports": [
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   }
                 ],
                 "env": [
@@ -147,8 +144,7 @@
                 "image": "centos/mariadb",
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [

--- a/script/test/fixtures/etherpad/output-os.json
+++ b/script/test/fixtures/etherpad/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "3306",
-            "protocol": "TCP",
             "port": 3306,
             "targetPort": 3306
           }
@@ -108,8 +106,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   }
                 ],
                 "env": [
@@ -227,8 +224,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,13 +46,11 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           },
           {
             "name": "4000",
-            "protocol": "TCP",
             "port": 4000,
             "targetPort": 4000
           }
@@ -89,8 +86,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -129,12 +125,10 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   },
                   {
-                    "containerPort": 4000,
-                    "protocol": "TCP"
+                    "containerPort": 4000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
@@ -20,7 +20,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -47,7 +46,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -86,8 +84,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}
@@ -151,8 +148,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,13 +46,11 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           },
           {
             "name": "4000",
-            "protocol": "TCP",
             "port": 4000,
             "targetPort": 4000
           }
@@ -89,8 +86,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -129,12 +125,10 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   },
                   {
-                    "containerPort": 4000,
-                    "protocol": "TCP"
+                    "containerPort": 4000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,7 +46,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -83,8 +81,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -123,8 +120,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json
@@ -20,13 +20,11 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           },
           {
             "name": "4000",
-            "protocol": "TCP",
             "port": 4000,
             "targetPort": 4000
           }
@@ -53,7 +51,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -120,12 +117,10 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   },
                   {
-                    "containerPort": 4000,
-                    "protocol": "TCP"
+                    "containerPort": 4000
                   }
                 ],
                 "resources": {}
@@ -235,8 +230,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,7 +46,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -111,8 +109,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -203,8 +200,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,13 +46,11 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           },
           {
             "name": "4000",
-            "protocol": "TCP",
             "port": 4000,
             "targetPort": 4000
           }
@@ -117,8 +114,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -209,12 +205,10 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   },
                   {
-                    "containerPort": 4000,
-                    "protocol": "TCP"
+                    "containerPort": 4000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -47,7 +46,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -111,8 +109,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -203,8 +200,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/gitlab/output-k8s.json
+++ b/script/test/fixtures/gitlab/output-k8s.json
@@ -26,8 +26,7 @@
                 "image": "swordphilic/postgresql",
                 "ports": [
                   {
-                    "containerPort": 5432,
-                    "protocol": "TCP"
+                    "containerPort": 5432
                   }
                 ],
                 "env": [
@@ -68,7 +67,6 @@
         "ports": [
           {
             "name": "5432",
-            "protocol": "TCP",
             "port": 5432,
             "targetPort": 5432
           }
@@ -104,8 +102,7 @@
                 "image": "swordphilic/redis",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -132,7 +129,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -168,16 +164,13 @@
                 "image": "swordphilic/gitlab",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   },
                   {
-                    "containerPort": 443,
-                    "protocol": "TCP"
+                    "containerPort": 443
                   },
                   {
-                    "containerPort": 22,
-                    "protocol": "TCP"
+                    "containerPort": 22
                   }
                 ],
                 "env": [
@@ -238,19 +231,16 @@
         "ports": [
           {
             "name": "30000",
-            "protocol": "TCP",
             "port": 30000,
             "targetPort": 80
           },
           {
             "name": "30001",
-            "protocol": "TCP",
             "port": 30001,
             "targetPort": 443
           },
           {
             "name": "30002",
-            "protocol": "TCP",
             "port": 30002,
             "targetPort": 22
           }

--- a/script/test/fixtures/gitlab/output-os.json
+++ b/script/test/fixtures/gitlab/output-os.json
@@ -17,19 +17,16 @@
         "ports": [
           {
             "name": "30000",
-            "protocol": "TCP",
             "port": 30000,
             "targetPort": 80
           },
           {
             "name": "30001",
-            "protocol": "TCP",
             "port": 30001,
             "targetPort": 443
           },
           {
             "name": "30002",
-            "protocol": "TCP",
             "port": 30002,
             "targetPort": 22
           }
@@ -56,7 +53,6 @@
         "ports": [
           {
             "name": "5432",
-            "protocol": "TCP",
             "port": 5432,
             "targetPort": 5432
           }
@@ -83,7 +79,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -147,16 +142,13 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   },
                   {
-                    "containerPort": 443,
-                    "protocol": "TCP"
+                    "containerPort": 443
                   },
                   {
-                    "containerPort": 22,
-                    "protocol": "TCP"
+                    "containerPort": 22
                   }
                 ],
                 "env": [
@@ -278,8 +270,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5432,
-                    "protocol": "TCP"
+                    "containerPort": 5432
                   }
                 ],
                 "env": [
@@ -381,8 +372,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/keyonly-envs/output-k8s.json
+++ b/script/test/fixtures/keyonly-envs/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -71,7 +69,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -107,8 +104,7 @@
                 "image": "gcr.io/google-samples/gb-frontend:v4",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "env": [
@@ -162,8 +158,7 @@
                 "image": "gcr.io/google_containers/redis:e2e",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -199,8 +194,7 @@
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "env": [

--- a/script/test/fixtures/multiple-compose-files/output-k8s.json
+++ b/script/test/fixtures/multiple-compose-files/output-k8s.json
@@ -17,13 +17,11 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           },
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           }
@@ -50,13 +48,11 @@
         "ports": [
           {
             "name": "3306",
-            "protocol": "TCP",
             "port": 3306,
             "targetPort": 3306
           },
           {
             "name": "3307",
-            "protocol": "TCP",
             "port": 3307,
             "targetPort": 3307
           }
@@ -92,12 +88,10 @@
                 "image": "centos/etherpad",
                 "ports": [
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   },
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   }
                 ],
                 "env": [
@@ -169,12 +163,10 @@
                 "image": "centos/mariadb",
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   },
                   {
-                    "containerPort": 3307,
-                    "protocol": "TCP"
+                    "containerPort": 3307
                   }
                 ],
                 "env": [

--- a/script/test/fixtures/multiple-compose-files/output-openshift.json
+++ b/script/test/fixtures/multiple-compose-files/output-openshift.json
@@ -17,13 +17,11 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           },
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 9001
           }
@@ -50,13 +48,11 @@
         "ports": [
           {
             "name": "3306",
-            "protocol": "TCP",
             "port": 3306,
             "targetPort": 3306
           },
           {
             "name": "3307",
-            "protocol": "TCP",
             "port": 3307,
             "targetPort": 3307
           }
@@ -120,12 +116,10 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   },
                   {
-                    "containerPort": 9001,
-                    "protocol": "TCP"
+                    "containerPort": 9001
                   }
                 ],
                 "env": [
@@ -249,12 +243,10 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   },
                   {
-                    "containerPort": 3307,
-                    "protocol": "TCP"
+                    "containerPort": 3307
                   }
                 ],
                 "env": [

--- a/script/test/fixtures/ngnix-node-redis/output-k8s.json
+++ b/script/test/fixtures/ngnix-node-redis/output-k8s.json
@@ -25,8 +25,7 @@
                 "name": "node2",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}
@@ -53,7 +52,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -88,8 +86,7 @@
                 "name": "node3",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}
@@ -116,7 +113,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -152,8 +148,7 @@
                 "image": "redis",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -180,7 +175,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -215,8 +209,7 @@
                 "name": "nginx",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {}
@@ -243,7 +236,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -278,8 +270,7 @@
                 "name": "node1",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}
@@ -306,7 +297,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }

--- a/script/test/fixtures/ngnix-node-redis/output-os.json
+++ b/script/test/fixtures/ngnix-node-redis/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -71,7 +69,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -98,7 +95,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -125,7 +121,6 @@
         "ports": [
           {
             "name": "8080",
-            "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
           }
@@ -189,8 +184,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}
@@ -307,8 +301,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -396,8 +389,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {}
@@ -514,8 +506,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}
@@ -632,8 +623,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
+                    "containerPort": 8080
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/ports-with-proto/output-k8s.json
+++ b/script/test/fixtures/ports-with-proto/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           },
@@ -86,8 +84,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}
@@ -123,8 +120,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   },
                   {
                     "containerPort": 1235,

--- a/script/test/fixtures/ports-with-proto/output-os.json
+++ b/script/test/fixtures/ports-with-proto/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           },
@@ -50,7 +49,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -114,8 +112,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   },
                   {
                     "containerPort": 1235,
@@ -207,8 +204,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/stdin-true/output-k8s.json
+++ b/script/test/fixtures/stdin-true/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "1337",
-            "protocol": "TCP",
             "port": 1337,
             "targetPort": 1337
           }
@@ -53,8 +52,7 @@
                 "image": "registry.centos.org/centos/centos:7",
                 "ports": [
                   {
-                    "containerPort": 1337,
-                    "protocol": "TCP"
+                    "containerPort": 1337
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/stdin-true/output-oc.json
+++ b/script/test/fixtures/stdin-true/output-oc.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "1337",
-            "protocol": "TCP",
             "port": 1337,
             "targetPort": 1337
           }
@@ -81,8 +80,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 1337,
-                    "protocol": "TCP"
+                    "containerPort": 1337
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/tty-true/output-k8s.json
+++ b/script/test/fixtures/tty-true/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "1337",
-            "protocol": "TCP",
             "port": 1337,
             "targetPort": 1337
           }
@@ -53,8 +52,7 @@
                 "image": "registry.centos.org/centos/centos:7",
                 "ports": [
                   {
-                    "containerPort": 1337,
-                    "protocol": "TCP"
+                    "containerPort": 1337
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/tty-true/output-oc.json
+++ b/script/test/fixtures/tty-true/output-oc.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "1337",
-            "protocol": "TCP",
             "port": 1337,
             "targetPort": 1337
           }
@@ -81,8 +80,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 1337,
-                    "protocol": "TCP"
+                    "containerPort": 1337
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s.json
+++ b/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -61,8 +60,7 @@
                 "image": "docker.io/fedora/apache",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/volume-mounts/simple-vol-mounts/output-os.json
+++ b/script/test/fixtures/volume-mounts/simple-vol-mounts/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -89,8 +88,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/volume-mounts/volumes-from/output-k8s.json
+++ b/script/test/fixtures/volume-mounts/volumes-from/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "3030",
-            "protocol": "TCP",
             "port": 3030,
             "targetPort": 3000
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -93,8 +91,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3000,
-                    "protocol": "TCP"
+                    "containerPort": 3000
                   }
                 ],
                 "resources": {},
@@ -169,8 +166,7 @@
                 "image": "nginx",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/volume-mounts/volumes-from/output-os.json
+++ b/script/test/fixtures/volume-mounts/volumes-from/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "80",
-            "protocol": "TCP",
             "port": 80,
             "targetPort": 80
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "3030",
-            "protocol": "TCP",
             "port": 3030,
             "targetPort": 3000
           }
@@ -122,8 +120,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 80,
-                    "protocol": "TCP"
+                    "containerPort": 80
                   }
                 ],
                 "resources": {},
@@ -253,8 +250,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3000,
-                    "protocol": "TCP"
+                    "containerPort": 3000
                   }
                 ],
                 "resources": {},

--- a/script/test/fixtures/yaml-and-yml/output-k8s.json
+++ b/script/test/fixtures/yaml-and-yml/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -80,8 +78,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -117,8 +114,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/yaml-and-yml/output-os.json
+++ b/script/test/fixtures/yaml-and-yml/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -108,8 +106,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -197,8 +194,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/yaml-and-yml/yml/output-k8s.json
+++ b/script/test/fixtures/yaml-and-yml/yml/output-k8s.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -80,8 +78,7 @@
                 "image": "redis:3.0",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -117,8 +114,7 @@
                 "image": "tuna/docker-counter23",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/yaml-and-yml/yml/output-os.json
+++ b/script/test/fixtures/yaml-and-yml/yml/output-os.json
@@ -17,7 +17,6 @@
         "ports": [
           {
             "name": "6379",
-            "protocol": "TCP",
             "port": 6379,
             "targetPort": 6379
           }
@@ -44,7 +43,6 @@
         "ports": [
           {
             "name": "5000",
-            "protocol": "TCP",
             "port": 5000,
             "targetPort": 5000
           }
@@ -108,8 +106,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 6379,
-                    "protocol": "TCP"
+                    "containerPort": 6379
                   }
                 ],
                 "resources": {}
@@ -197,8 +194,7 @@
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 5000,
-                    "protocol": "TCP"
+                    "containerPort": 5000
                   }
                 ],
                 "resources": {}


### PR DESCRIPTION
If TCP is passed in as the protocol, by default, we add TCP as the
protocol within the Kubernetes or OpenShift artifacts.

By default, TCP is already selected within Kubernetes and thus having
the TCP output is redundant.

This commit checks to see if TCP has already been selected, and if it
has, ignores adding it to the list of ports.

Closes https://github.com/kubernetes-incubator/kompose/issues/392