### PR TITLE
add BuildConfig support to kompose down

### DIFF
--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -509,6 +509,13 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			}
 			logrus.Infof("Successfully deleted ImageStream: %s", t.Name)
 
+		case *buildapi.BuildConfig:
+			err := oclient.BuildConfigs(namespace).Delete(t.Name)
+			if err != nil {
+				return err
+			}
+			logrus.Infof("Successfully deleted BuildConfig: %s", t.Name)
+
 		case *deployapi.DeploymentConfig:
 			// delete deploymentConfig
 			dcreaper := deploymentconfigreaper.NewDeploymentConfigReaper(oclient, kclient)


### PR DESCRIPTION
``` 
kompose --provider openshift up
INFO Successfully created Service: foo            
INFO Successfully created DeploymentConfig: foo   
INFO Successfully created ImageStream: foo        
INFO Successfully created BuildConfig: foo 
```
```
kompose --provider openshift down
INFO Buildconfig using https://github.com/kubernetes-incubator/kompose.git::master as source. 
INFO Successfully deleted service: foo            
INFO Successfully deleted DeploymentConfig: foo   
INFO Successfully deleted ImageStream: foo        
INFO Successfully deleted BuildConfig: foo   
```
docker-compose file used is [docker-compose.yml](https://github.com/kubernetes-incubator/kompose/tree/master/examples/buildconfig)

@kadel @cdrage @containscafeine Review please.
Fixes #382  