### PR TITLE
Update Makefile - lazy set for PKGS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 GITCOMMIT := $(shell git rev-parse --short HEAD)
 BUILD_FLAGS := -ldflags="-w -X github.com/kubernetes-incubator/kompose/cmd.GITCOMMIT=$(GITCOMMIT)"
-PKGS := $(shell glide novendor)
+PKGS = $(shell glide novendor)
 TEST_IMAGE := kompose/tests:latest
 
 default: bin


### PR DESCRIPTION
Using lazy set we can run targets that don't $PKGS without requiring glide.

Lazy set is expended when variable is used, not when declared.