### PR TITLE
removed unnecessary objects in compose.go

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var completion = &cobra.Command{

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -33,12 +33,13 @@ import (
 	_ "github.com/openshift/origin/pkg/image/api/install"
 	_ "github.com/openshift/origin/pkg/route/api/install"
 
+	"os"
+
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 	"github.com/kubernetes-incubator/kompose/pkg/loader"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/kubernetes"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/openshift"
-	"os"
 )
 
 const (


### PR DESCRIPTION
In `compoese.go` while iterating on the `ServiceConfig` objects first it's keys were pulled and then data was pulled separately which can be done in one step by iterating on the dictionary.