### PR TITLE
normalize docker-compose service that has name with underscore

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var completion = &cobra.Command{

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -33,12 +33,13 @@ import (
 	_ "github.com/openshift/origin/pkg/image/api/install"
 	_ "github.com/openshift/origin/pkg/route/api/install"
 
+	"os"
+
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 	"github.com/kubernetes-incubator/kompose/pkg/loader"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/kubernetes"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer/openshift"
-	"os"
 )
 
 const (

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -391,3 +391,7 @@ func handleServiceType(ServiceType string) string {
 		return ""
 	}
 }
+
+func normalizeServiceNames(svcName string) string {
+	return strings.Replace(svcName, "_", "-", -1)
+}

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -263,3 +263,22 @@ func TestUnsupportedKeys(t *testing.T) {
 	}
 
 }
+
+func TestNormalizeServiceNames(t *testing.T) {
+	testCases := []struct {
+		composeServiceName    string
+		normalizedServiceName string
+	}{
+		{"foo_bar", "foo-bar"},
+		{"foo", "foo"},
+		{"foo.bar", "foo.bar"},
+		//{"", ""},
+	}
+
+	for _, testCase := range testCases {
+		returnValue := normalizeServiceNames(testCase.composeServiceName)
+		if returnValue != testCase.normalizedServiceName {
+			t.Logf("Expected %q, got %q", testCase.normalizedServiceName, returnValue)
+		}
+	}
+}


### PR DESCRIPTION
kubernetes or openshift does not allow underscores in the object
names, while docker-compose does, in this commit the code has been
added to convert underscores to hypens.

Fixes #420