### PR TITLE
Test with multiple go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ sudo: required
 
 language: go
 
+# make this also work for forks
+go_import_path: github.com/kubernetes-incubator/kompose
+
+
 go:
   - 1.6
+  - 1.7
+  - 1.8
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -57,32 +57,32 @@ type ConvertOptions struct {
 type ServiceConfig struct {
 	// use tags to mark from what element this value comes
 	ContainerName string
-	Image         string              `compose:"image",bundle:"Image"`
-	Environment   []EnvVar            `compose:"environment",bundle:"Env"`
-	Port          []Ports             `compose:"ports",bundle:"Ports"`
-	Command       []string            `compose:"command",bundle:"Command"`
-	WorkingDir    string              `compose:"",bundle:"WorkingDir"`
-	Args          []string            `compose:"args",bundle:"Args"`
-	Volumes       []string            `compose:"volumes",bundle:"Volumes"`
-	Network       []string            `compose:"network",bundle:"Networks"`
-	Labels        map[string]string   `compose:"labels",bundle:"Labels"`
-	Annotations   map[string]string   `compose:"",bundle:""`
-	CPUSet        string              `compose:"cpuset",bundle:""`
-	CPUShares     int64               `compose:"cpu_shares",bundle:""`
-	CPUQuota      int64               `compose:"cpu_quota",bundle:""`
-	CapAdd        []string            `compose:"cap_add",bundle:""`
-	CapDrop       []string            `compose:"cap_drop",bundle:""`
-	Expose        []string            `compose:"expose",bundle:""`
-	Privileged    bool                `compose:"privileged",bundle:""`
-	Restart       string              `compose:"restart",bundle:""`
-	User          string              `compose:"user",bundle:"User"`
-	VolumesFrom   []string            `compose:"volumes_from",bundle:""`
-	ServiceType   string              `compose:"kompose.service.type",bundle:""`
-	Build         string              `compose:"build",bundle:""`
-	ExposeService string              `compose:"kompose.service.expose",bundle:""`
-	Stdin         bool                `compose:"stdin_open",bundle:""`
-	Tty           bool                `compose:"tty",bundle:""`
-	MemLimit      yaml.MemStringorInt `compose:"mem_limit",bundle:""`
+	Image         string              `compose:"image" bundle:"Image"`
+	Environment   []EnvVar            `compose:"environment" bundle:"Env"`
+	Port          []Ports             `compose:"ports" bundle:"Ports"`
+	Command       []string            `compose:"command" bundle:"Command"`
+	WorkingDir    string              `compose:"" bundle:"WorkingDir"`
+	Args          []string            `compose:"args" bundle:"Args"`
+	Volumes       []string            `compose:"volumes" bundle:"Volumes"`
+	Network       []string            `compose:"network" bundle:"Networks"`
+	Labels        map[string]string   `compose:"labels" bundle:"Labels"`
+	Annotations   map[string]string   `compose:"" bundle:""`
+	CPUSet        string              `compose:"cpuset" bundle:""`
+	CPUShares     int64               `compose:"cpu_shares" bundle:""`
+	CPUQuota      int64               `compose:"cpu_quota" bundle:""`
+	CapAdd        []string            `compose:"cap_add" bundle:""`
+	CapDrop       []string            `compose:"cap_drop" bundle:""`
+	Expose        []string            `compose:"expose" bundle:""`
+	Privileged    bool                `compose:"privileged" bundle:""`
+	Restart       string              `compose:"restart" bundle:""`
+	User          string              `compose:"user" bundle:"User"`
+	VolumesFrom   []string            `compose:"volumes_from" bundle:""`
+	ServiceType   string              `compose:"kompose.service.type" bundle:""`
+	Build         string              `compose:"build" bundle:""`
+	ExposeService string              `compose:"kompose.service.expose" bundle:""`
+	Stdin         bool                `compose:"stdin_open" bundle:""`
+	Tty           bool                `compose:"tty" bundle:""`
+	MemLimit      yaml.MemStringorInt `compose:"mem_limit" bundle:""`
 }
 
 // EnvVar holds the environment variable struct of a container


### PR DESCRIPTION
`go vet` in go 1.8 started complaining about tag format.

```
pkg/kobject/kobject.go:60: struct field tag `compose:"image",bundle:"Image"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```

This fixes tag formatting in KObject and updates travis.yaml so it runs tests on multiple go versions 1.6, 1.7 and 1.8


