### PR TITLE
Update the README with -u in go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install `kompose`, you can either `go get` or install the binary from a new r
 #### Go
 
 ```sh
-go get github.com/kubernetes-incubator/kompose
+go get -u github.com/kubernetes-incubator/kompose
 ```
 
 #### GitHub release


### PR DESCRIPTION
Updates the readme to include -u in `go get` in order to upgrade
already-installed versions of Kompose.