### PR TITLE
Clean up logrus

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ var completion = &cobra.Command{
 
 		err := Generate(cmd, args)
 		if err != nil {
-			logrus.Fatalf("Error: %s", err)
+			log.Fatalf("Error: %s", err)
 		}
 
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,12 +30,12 @@ import (
 // Hook for erroring and exit out on warning
 type errorOnWarningHook struct{}
 
-func (errorOnWarningHook) Levels() []logrus.Level {
-	return []logrus.Level{logrus.WarnLevel}
+func (errorOnWarningHook) Levels() []log.Level {
+	return []log.Level{log.WarnLevel}
 }
 
-func (errorOnWarningHook) Fire(entry *logrus.Entry) error {
-	logrus.Fatalln(entry.Message)
+func (errorOnWarningHook) Fire(entry *log.Entry) error {
+	log.Fatalln(entry.Message)
 	return nil
 }
 
@@ -61,27 +61,27 @@ var RootCmd = &cobra.Command{
 
 		// Add extra logging when verbosity is passed
 		if GlobalVerbose {
-			logrus.SetLevel(logrus.DebugLevel)
+			log.SetLevel(log.DebugLevel)
 		}
 
 		// Disable the timestamp (Kompose is too fast!)
-		formatter := new(logrus.TextFormatter)
+		formatter := new(log.TextFormatter)
 		formatter.DisableTimestamp = true
 		formatter.ForceColors = true
-		logrus.SetFormatter(formatter)
+		log.SetFormatter(formatter)
 
 		// Set the appropriate suppress warnings and error on warning flags
 		if GlobalSuppressWarnings {
-			logrus.SetLevel(logrus.ErrorLevel)
+			log.SetLevel(log.ErrorLevel)
 		} else if GlobalErrorOnWarning {
 			hook := errorOnWarningHook{}
-			logrus.AddHook(hook)
+			log.AddHook(hook)
 		}
 
 		// Error out of the user has not chosen Kubernetes or OpenShift
 		provider := strings.ToLower(GlobalProvider)
 		if provider != "kubernetes" && provider != "openshift" {
-			logrus.Fatalf("%s is an unsupported provider. Supported providers are: 'kubernetes', 'openshift'.", GlobalProvider)
+			log.Fatalf("%s is an unsupported provider. Supported providers are: 'kubernetes', 'openshift'.", GlobalProvider)
 		}
 
 	},

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	// install kubernetes api
@@ -64,7 +64,7 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 
 	// Get the provider
 	provider := cmd.Flags().Lookup("provider").Value.String()
-	logrus.Debug("Checking validation of provider %s", provider)
+	log.Debug("Checking validation of provider %s", provider)
 
 	// OpenShift specific flags
 	deploymentConfig := cmd.Flags().Lookup("deployment-config").Changed
@@ -81,40 +81,40 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 	switch {
 	case provider == "openshift":
 		if chart {
-			logrus.Fatalf("--chart, -c is a Kubernetes only flag")
+			log.Fatalf("--chart, -c is a Kubernetes only flag")
 		}
 		if daemonSet {
-			logrus.Fatalf("--daemon-set is a Kubernetes only flag")
+			log.Fatalf("--daemon-set is a Kubernetes only flag")
 		}
 		if replicationController {
-			logrus.Fatalf("--replication-controller is a Kubernetes only flag")
+			log.Fatalf("--replication-controller is a Kubernetes only flag")
 		}
 		if deployment {
-			logrus.Fatalf("--deployment, -d is a Kubernetes only flag")
+			log.Fatalf("--deployment, -d is a Kubernetes only flag")
 		}
 	case provider == "kubernetes":
 		if deploymentConfig {
-			logrus.Fatalf("--deployment-config is an OpenShift only flag")
+			log.Fatalf("--deployment-config is an OpenShift only flag")
 		}
 		if buildRepo {
-			logrus.Fatalf("--build-repo is an Openshift only flag")
+			log.Fatalf("--build-repo is an Openshift only flag")
 		}
 		if buildBranch {
-			logrus.Fatalf("--build-branch is an Openshift only flag")
+			log.Fatalf("--build-branch is an Openshift only flag")
 		}
 	}
 
 	// Standard checks regardless of provider
 	if len(opt.OutFile) != 0 && opt.ToStdout {
-		logrus.Fatalf("Error: --out and --stdout can't be set at the same time")
+		log.Fatalf("Error: --out and --stdout can't be set at the same time")
 	}
 
 	if opt.CreateChart && opt.ToStdout {
-		logrus.Fatalf("Error: chart cannot be generated when --stdout is specified")
+		log.Fatalf("Error: chart cannot be generated when --stdout is specified")
 	}
 
 	if opt.Replicas < 0 {
-		logrus.Fatalf("Error: --replicas cannot be negative")
+		log.Fatalf("Error: --replicas cannot be negative")
 	}
 
 	if len(bundle) > 0 {
@@ -123,15 +123,15 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 	}
 
 	if len(bundle) > 0 && isFileSet {
-		logrus.Fatalf("Error: 'compose' file and 'dab' file cannot be specified at the same time")
+		log.Fatalf("Error: 'compose' file and 'dab' file cannot be specified at the same time")
 	}
 
 	if len(args) != 0 {
-		logrus.Fatal("Unknown Argument(s): ", strings.Join(args, ","))
+		log.Fatal("Unknown Argument(s): ", strings.Join(args, ","))
 	}
 
 	if opt.GenerateJSON && opt.GenerateYaml {
-		logrus.Fatalf("YAML and JSON format cannot be provided at the same time")
+		log.Fatalf("YAML and JSON format cannot be provided at the same time")
 	}
 }
 
@@ -142,11 +142,11 @@ func ValidateComposeFile(cmd *cobra.Command, opt *kobject.ConvertOptions) {
 		opt.InputFiles = []string{"docker-compose.yml"}
 		_, err := os.Stat("docker-compose.yml")
 		if err != nil {
-			logrus.Debugf("'docker-compose.yml' not found: %v", err)
+			log.Debugf("'docker-compose.yml' not found: %v", err)
 			opt.InputFiles = []string{"docker-compose.yaml"}
 			_, err = os.Stat("docker-compose.yaml")
 			if err != nil {
-				logrus.Fatalf("No 'docker-compose' file found: %v", err)
+				log.Fatalf("No 'docker-compose' file found: %v", err)
 			}
 		}
 	}
@@ -173,7 +173,7 @@ func validateControllers(opt *kobject.ConvertOptions) {
 				count++
 			}
 			if count > 1 {
-				logrus.Fatalf("Error: only one kind of Kubernetes resource can be generated when --out or --stdout is specified")
+				log.Fatalf("Error: only one kind of Kubernetes resource can be generated when --out or --stdout is specified")
 			}
 		}
 
@@ -191,7 +191,7 @@ func validateControllers(opt *kobject.ConvertOptions) {
 			// if opt.foo {count++}
 
 			if count > 1 {
-				logrus.Fatalf("Error: only one kind of OpenShift resource can be generated when --out or --stdout is specified")
+				log.Fatalf("Error: only one kind of OpenShift resource can be generated when --out or --stdout is specified")
 			}
 		}
 	}
@@ -205,7 +205,7 @@ func Convert(opt kobject.ConvertOptions) {
 	// loader parses input from file into komposeObject.
 	l, err := loader.GetLoader(inputFormat)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	komposeObject := kobject.KomposeObject{
@@ -231,7 +231,7 @@ func Up(opt kobject.ConvertOptions) {
 	// loader parses input from file into komposeObject.
 	l, err := loader.GetLoader(inputFormat)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	komposeObject := kobject.KomposeObject{
@@ -245,7 +245,7 @@ func Up(opt kobject.ConvertOptions) {
 	//Submit objects to provider
 	errDeploy := t.Deploy(komposeObject, opt)
 	if errDeploy != nil {
-		logrus.Fatalf("Error while deploying application: %s", errDeploy)
+		log.Fatalf("Error while deploying application: %s", errDeploy)
 	}
 }
 
@@ -257,7 +257,7 @@ func Down(opt kobject.ConvertOptions) {
 	// loader parses input from file into komposeObject.
 	l, err := loader.GetLoader(inputFormat)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	komposeObject := kobject.KomposeObject{
@@ -271,7 +271,7 @@ func Down(opt kobject.ConvertOptions) {
 	//Remove deployed application
 	errUndeploy := t.Undeploy(komposeObject, opt)
 	if errUndeploy != nil {
-		logrus.Fatalf("Error while deleting application: %s", errUndeploy)
+		log.Fatalf("Error while deleting application: %s", errUndeploy)
 	}
 
 }
@@ -295,7 +295,7 @@ func askForConfirmation() bool {
 	var response string
 	_, err := fmt.Scanln(&response)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 	if response == "yes" {
 		return true

--- a/pkg/loader/bundle/bundle.go
+++ b/pkg/loader/bundle/bundle.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/fatih/structs"
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 )
@@ -182,17 +182,17 @@ func (b *Bundle) LoadFile(files []string) kobject.KomposeObject {
 	file := files[0]
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {
-		logrus.Fatalf("Failed to read bundles file: %s ", err)
+		log.Fatalf("Failed to read bundles file: %s ", err)
 	}
 	reader := strings.NewReader(string(buf))
 	bundle, err := loadFile(reader)
 	if err != nil {
-		logrus.Fatalf("Failed to parse bundles file: %s", err)
+		log.Fatalf("Failed to parse bundles file: %s", err)
 	}
 
 	noSupKeys := checkUnsupportedKey(bundle)
 	for _, keyName := range noSupKeys {
-		logrus.Warningf("Unsupported %s key - ignoring", keyName)
+		log.Warningf("Unsupported %s key - ignoring", keyName)
 	}
 
 	for name, service := range bundle.Services {
@@ -205,19 +205,19 @@ func (b *Bundle) LoadFile(files []string) kobject.KomposeObject {
 
 		image, err := loadImage(service)
 		if err != "" {
-			logrus.Fatalf("Failed to load image from bundles file: " + err)
+			log.Fatalf("Failed to load image from bundles file: " + err)
 		}
 		serviceConfig.Image = image
 
 		envs, err := loadEnvVars(service)
 		if err != "" {
-			logrus.Fatalf("Failed to load envvar from bundles file: " + err)
+			log.Fatalf("Failed to load envvar from bundles file: " + err)
 		}
 		serviceConfig.Environment = envs
 
 		ports, err := loadPorts(service)
 		if err != "" {
-			logrus.Fatalf("Failed to load ports from bundles file: " + err)
+			log.Fatalf("Failed to load ports from bundles file: " + err)
 		}
 		serviceConfig.Port = ports
 

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -27,7 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/lookup"
 	"github.com/docker/libcompose/project"
@@ -86,7 +86,7 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 	// Check to see if the default network is available and length is only equal to one.
 	// Else, warn the user that root level networks are not supported (yet)
 	if _, ok := composeProject.NetworkConfigs["default"]; ok && len(composeProject.NetworkConfigs) == 1 {
-		logrus.Debug("Default network found")
+		log.Debug("Default network found")
 	} else if len(composeProject.NetworkConfigs) > 0 {
 		keysFound = append(keysFound, "root level networks")
 	}
@@ -303,12 +303,12 @@ func (c *Compose) LoadFile(files []string) kobject.KomposeObject {
 	composeObject := project.NewProject(context, nil, nil)
 	err := composeObject.Parse()
 	if err != nil {
-		logrus.Fatalf("Failed to load compose file: %v", err)
+		log.Fatalf("Failed to load compose file: %v", err)
 	}
 
 	noSupKeys := checkUnsupportedKey(composeObject)
 	for _, keyName := range noSupKeys {
-		logrus.Warningf("Unsupported %s key - ignoring", keyName)
+		log.Warningf("Unsupported %s key - ignoring", keyName)
 	}
 
 	for name, composeServiceConfig := range composeObject.ServiceConfigs.All() {
@@ -326,7 +326,7 @@ func (c *Compose) LoadFile(files []string) kobject.KomposeObject {
 		// load ports
 		ports, err := loadPorts(composeServiceConfig.Ports)
 		if err != nil {
-			logrus.Fatalf("%q failed to load ports from compose file: %v", name, err)
+			log.Fatalf("%q failed to load ports from compose file: %v", name, err)
 		}
 		serviceConfig.Port = ports
 
@@ -382,7 +382,7 @@ func handleServiceType(ServiceType string) string {
 	case "loadbalancer":
 		return string(api.ServiceTypeLoadBalancer)
 	default:
-		logrus.Fatalf("Unknown value '%s', supported values are 'NodePort, ClusterIP or LoadBalancer'", ServiceType)
+		log.Fatalf("Unknown value '%s', supported values are 'NodePort, ClusterIP or LoadBalancer'", ServiceType)
 		return ""
 	}
 }

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/ghodss/yaml"
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer"
@@ -92,7 +92,7 @@ home:
 
 		t, err := template.New("ChartTmpl").Parse(chart)
 		if err != nil {
-			logrus.Fatalf("Failed to generate Chart.yaml template: %s\n", err)
+			log.Fatalf("Failed to generate Chart.yaml template: %s\n", err)
 		}
 		var chartData bytes.Buffer
 		_ = t.Execute(&chartData, details)
@@ -106,20 +106,20 @@ home:
 	/* Copy all related json/yaml files into the newly created manifests directory */
 	for _, filename := range outFiles {
 		if err = cpFileToChart(manifestDir, filename); err != nil {
-			logrus.Warningln(err)
+			log.Warningln(err)
 		}
 		if err = os.Remove(filename); err != nil {
-			logrus.Warningln(err)
+			log.Warningln(err)
 		}
 	}
-	logrus.Infof("chart created in %q\n", "."+string(os.PathSeparator)+dirName+string(os.PathSeparator))
+	log.Infof("chart created in %q\n", "."+string(os.PathSeparator)+dirName+string(os.PathSeparator))
 	return nil
 }
 
 func cpFileToChart(manifestDir, filename string) error {
 	infile, err := ioutil.ReadFile(filename)
 	if err != nil {
-		logrus.Warningf("Error reading %s: %s\n", filename, err)
+		log.Warningf("Error reading %s: %s\n", filename, err)
 		return err
 	}
 
@@ -139,7 +139,7 @@ func isDir(name string) bool {
 	// Get file attributes and information
 	fileStat, err := f.Stat()
 	if err != nil {
-		logrus.Fatalf("error retrieving file information: %v", err)
+		log.Fatalf("error retrieving file information: %v", err)
 	}
 
 	// Check if given path is a directory
@@ -259,7 +259,7 @@ func convertToVersion(obj runtime.Object, groupVersion unversioned.GroupVersion)
 // PortsExist checks if service has ports defined
 func (k *Kubernetes) PortsExist(name string, service kobject.ServiceConfig) bool {
 	if len(service.Port) == 0 {
-		logrus.Debugf("[%s] No ports defined. Headless service will be created.", name)
+		log.Debugf("[%s] No ports defined. Headless service will be created.", name)
 		return false
 	}
 	return true
@@ -360,7 +360,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		if service.User != "" {
 			uid, err := strconv.ParseInt(service.User, 10, 64)
 			if err != nil {
-				logrus.Warn("Ignoring user directive. User to be specified as a UID (numeric).")
+				log.Warn("Ignoring user directive. User to be specified as a UID (numeric).")
 			} else {
 				securityContext.RunAsUser = &uid
 			}
@@ -384,7 +384,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		case "on-failure":
 			template.Spec.RestartPolicy = api.RestartPolicyOnFailure
 		default:
-			logrus.Fatalf("Unknown restart policy %s for service %s", service.Restart, name)
+			log.Fatalf("Unknown restart policy %s for service %s", service.Restart, name)
 		}
 	}
 

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/fatih/structs"
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 	"github.com/kubernetes-incubator/kompose/pkg/transformer"
@@ -240,7 +240,7 @@ func (k *Kubernetes) initIngress(name string, service kobject.ServiceConfig, por
 func (k *Kubernetes) CreatePVC(name string, mode string) *api.PersistentVolumeClaim {
 	size, err := resource.ParseQuantity("100Mi")
 	if err != nil {
-		logrus.Fatalf("Error parsing size")
+		log.Fatalf("Error parsing size")
 	}
 
 	pvc := &api.PersistentVolumeClaim{
@@ -338,11 +338,11 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 
 		volumeName, host, container, mode, err := transformer.ParseVolume(volume)
 		if err != nil {
-			logrus.Warningf("Failed to configure container volume: %v", err)
+			log.Warningf("Failed to configure container volume: %v", err)
 			continue
 		}
 
-		logrus.Debug("Volume name %s", volumeName)
+		log.Debug("Volume name %s", volumeName)
 
 		// check if ro/rw mode is defined, default rw
 		readonly := len(mode) > 0 && mode == "ro"
@@ -382,7 +382,7 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 		volumes = append(volumes, vol)
 
 		if len(host) > 0 {
-			logrus.Warningf("Volume mount on the host %q isn't supported - ignoring path on the host", host)
+			log.Warningf("Volume mount on the host %q isn't supported - ignoring path on the host", host)
 		}
 	}
 	return volumeMounts, volumes, PVCs
@@ -456,7 +456,7 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 
 	noSupKeys := k.CheckUnsupportedKey(&komposeObject, unsupportedKey)
 	for _, keyName := range noSupKeys {
-		logrus.Warningf("Kubernetes provider doesn't support %s key - ignoring", keyName)
+		log.Warningf("Kubernetes provider doesn't support %s key - ignoring", keyName)
 	}
 
 	// this will hold all the converted data
@@ -477,7 +477,7 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 		if service.Restart == "no" || service.Restart == "on-failure" {
 			// Error out if Controller Object is specified with restart: 'on-failure'
 			if opt.IsDeploymentFlag || opt.IsDaemonSetFlag || opt.IsReplicationControllerFlag {
-				logrus.Fatalf("Controller object cannot be specified with restart: 'on-failure'")
+				log.Fatalf("Controller object cannot be specified with restart: 'on-failure'")
 			}
 			pod := k.InitPod(name, service)
 			objects = append(objects, pod)
@@ -581,31 +581,31 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully created Deployment: %s", t.Name)
+			log.Infof("Successfully created Deployment: %s", t.Name)
 		case *api.Service:
 			_, err := client.Services(namespace).Create(t)
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully created Service: %s", t.Name)
+			log.Infof("Successfully created Service: %s", t.Name)
 		case *api.PersistentVolumeClaim:
 			_, err := client.PersistentVolumeClaims(namespace).Create(t)
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully created PersistentVolumeClaim: %s", t.Name)
+			log.Infof("Successfully created PersistentVolumeClaim: %s", t.Name)
 		case *extensions.Ingress:
 			_, err := client.Ingress(namespace).Create(t)
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully created Ingress: %s", t.Name)
+			log.Infof("Successfully created Ingress: %s", t.Name)
 		case *api.Pod:
 			_, err := client.Pods(namespace).Create(t)
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully created Pod: %s", t.Name)
+			log.Infof("Successfully created Pod: %s", t.Name)
 		}
 	}
 
@@ -642,7 +642,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully deleted Deployment: %s", t.Name)
+			log.Infof("Successfully deleted Deployment: %s", t.Name)
 
 		case *api.Service:
 			//delete svc
@@ -655,7 +655,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully deleted Service: %s", t.Name)
+			log.Infof("Successfully deleted Service: %s", t.Name)
 
 		case *api.PersistentVolumeClaim:
 			// delete pvc
@@ -663,7 +663,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
+			log.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
 
 		case *extensions.Ingress:
 			// delete ingress
@@ -677,7 +677,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully deleted Ingress: %s", t.Name)
+			log.Infof("Successfully deleted Ingress: %s", t.Name)
 
 		case *api.Pod:
 			rpPod, err := kubectl.ReaperFor(api.Kind("Pod"), client)
@@ -689,7 +689,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Successfully deleted Pod: %s", t.Name)
+			log.Infof("Successfully deleted Pod: %s", t.Name)
 		}
 	}
 	return nil

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/ghodss/yaml"
 	"github.com/kubernetes-incubator/kompose/pkg/kobject"
 
@@ -53,7 +53,7 @@ func CreateOutFile(out string) *os.File {
 	if len(out) != 0 {
 		f, err = os.Create(out)
 		if err != nil {
-			logrus.Fatalf("error creating file: %v", err)
+			log.Fatalf("error creating file: %v", err)
 		}
 	}
 	return f
@@ -88,7 +88,7 @@ func ParseVolume(volume string) (name, host, container, mode string, err error) 
 	// See https://github.com/kubernetes-incubator/kompose/issues/176
 	// Otherwise, check to see if "rw" or "ro" has been passed
 	if possibleAccessMode == "z" || possibleAccessMode == "Z" {
-		logrus.Warnf("Volume mount \"%s\" will be mounted without labeling support. :z or :Z not supported", volume)
+		log.Warnf("Volume mount \"%s\" will be mounted without labeling support. :z or :Z not supported", volume)
 		mode = ""
 		volumeStrings = volumeStrings[:len(volumeStrings)-1]
 	} else if possibleAccessMode == "rw" || possibleAccessMode == "ro" {
@@ -146,7 +146,7 @@ func TransformData(obj runtime.Object, GenerateJSON bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	logrus.Debugf("%s\n", data)
+	log.Debugf("%s\n", data)
 	return data, nil
 }
 
@@ -164,16 +164,16 @@ func Print(name, path string, trailing string, data []byte, toStdout, generateJS
 	} else if f != nil {
 		// Write all content to a single file f
 		if _, err := f.WriteString(fmt.Sprintf("%s\n", string(data))); err != nil {
-			logrus.Fatalf("Failed to write %s to file: %v", trailing, err)
+			log.Fatalf("Failed to write %s to file: %v", trailing, err)
 		}
 		f.Sync()
 	} else {
 		// Write content separately to each file
 		file = filepath.Join(path, file)
 		if err := ioutil.WriteFile(file, []byte(data), 0644); err != nil {
-			logrus.Fatalf("Failed to write %s: %v", trailing, err)
+			log.Fatalf("Failed to write %s: %v", trailing, err)
 		}
-		logrus.Printf("file %q created", file)
+		log.Printf("file %q created", file)
 	}
 	return file
 }


### PR DESCRIPTION
Replaces "log" from "logrus" as commonly used in large Go projects.

Makes it easier from a developer perspective to use `log.Info`,
`log.Debug`, etc.