### PR TITLE
unsupported keys

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -76,6 +76,7 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 		"Ulimits":       false,
 		"Dockerfile":    false,
 		"Net":           false,
+		"Sysctls":       false,
 		"Networks":      false, // there are special checks for Network in checkUnsupportedKey function
 	}
 


### PR DESCRIPTION
@cdrage added `sysctls` to unsupported keys since we didn't find anything akin in Kubernetes.
Added `links` to unsupported keys since containers in the same pod can find and communicate with each other using `localhost:containerPort`

Fixes: #441 #439 