### PR TITLE
Adding kompose up/down tests for openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ test-unit-cover:
 	# generate go test commands using go list and run go test for every package separately 
 	go list -f '"go test -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kubernetes-incubator/kompose/...  | grep -v "vendor" | xargs -L 1 -P4 sh -c 
 
+
+# run openshift up/down tests
+.PHONY: test-openshift
+test-openshift:
+	./script/test_in_openshift/run.sh
+
 # run commandline tests
 .PHONY: test-cmd
 test-cmd:
@@ -89,7 +95,7 @@ test: check-vendor validate test-unit-cover install test-cmd
 .PHONY: test-image
 test-image:
 	docker build -t $(TEST_IMAGE) -f script/test_in_container/Dockerfile script/test_in_container/
-	
+
 # run all test localy in docker image (image can be build by by build-test-image target)
 .PHONY: test-container
 test-container:

--- a/examples/buildconfig/build/Dockerfile
+++ b/examples/buildconfig/build/Dockerfile
@@ -1,5 +1,4 @@
-FROM busybox
-
+FROM busybox:1.26.2
 
 RUN touch /test
 

--- a/script/test_in_openshift/compose-files/docker-compose-command.yml
+++ b/script/test_in_openshift/compose-files/docker-compose-command.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  base1:
+    image: busybox
+    command: ['sleep','10000']
+
+  base2:
+    image: busybox
+    entrypoint: ['sleep','10000']

--- a/script/test_in_openshift/lib.sh
+++ b/script/test_in_openshift/lib.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+function convert::print_msg () {
+    echo ""
+    tput setaf 4
+    tput bold
+    echo -e "$@"
+    tput sgr0
+    echo ""
+}
+
+function install_oc_client () {
+    # Valid only for Travis
+    convert::print_msg "Installing oc client binary ..."
+    sudo sed -i 's:DOCKER_OPTS=":DOCKER_OPTS="--insecure-registry 172.30.0.0/16 :g' /etc/default/docker
+    sudo mv /bin/findmnt /bin/findmnt.backup
+    sudo /etc/init.d/docker restart
+    # FIXME
+    wget https://github.com/openshift/origin/releases/download/v1.5.0/openshift-origin-client-tools-v1.5.0-031cbe4-linux-64bit.tar.gz -O /tmp/oc.tar.gz 2> /dev/null > /dev/null
+    mkdir /tmp/ocdir && cd /tmp/ocdir && tar -xvvf /tmp/oc.tar.gz > /dev/null
+    sudo mv /tmp/ocdir/*/oc /usr/bin/
+}
+
+
+function convert::oc_cluster_up () {
+
+    oc cluster up; exit_status=$?
+
+    if [ $exit_status -ne 0 ]; then
+	FAIL_MSGS=$FAIL_MSGS"exit status: $exit_status\n";
+	convert::print_fail "oc cluster up failed.\n"
+	exit $exit_status
+    fi
+
+    convert::run_cmd "oc login -u system:admin"
+}
+
+function convert::oc_cluster_down () {
+
+    convert::run_cmd "oc cluster down"
+    exit_status=$?
+
+    if [ $exit_status -ne 0 ]; then
+	FAIL_MSGS=$FAIL_MSGS"exit status: $exit_status\n"
+	exit $exit_status
+    fi
+
+}
+
+function convert::kompose_up_check () {
+    # A function to check if the pods are up in 'Running' state
+    # WARNING: This function has a limitation that it works only for 2 pods.
+    # TODO: Make this function work for any no. of pods
+    # Usage: -p for pod name, -r replica count
+    local retry_up=0
+
+    while getopts ":p:r:" opt; do
+	case $opt in
+	    p ) pod=$OPTARG;;
+	    r ) replica=$OPTARG;;
+	esac
+    done
+
+    if [ -z $replica ]; then
+       replica_1=1
+       replica_2=1
+    else
+       replica_1=$replica
+       replica_2=$replica
+    fi
+
+    pod_1=$( echo $pod | awk '{ print $1 }')
+    pod_2=$( echo $pod | awk '{ print $2 }')
+
+    query_1='grep ${pod_1} | grep -v deploy'
+    query_2='grep ${pod_2} | grep -v deploy'
+
+    query_1_status='Running'
+    query_2_status='Running'
+
+    is_buildconfig=$(oc get builds --no-headers | wc -l)
+
+    if [ $is_buildconfig -gt 0 ]; then
+	query_1='grep ${pod_1} | grep -v deploy | grep -v build'
+	query_2='grep build | grep -v deploy'
+	query_2_status='Completed'
+	replica_2=1
+    fi
+
+    convert::print_msg "Waiting for the pods to come up ..."
+
+    # FIXME: Make this generic to cover all cases
+    while [ $(oc get pods | eval ${query_1} | awk '{ print $3 }' | \
+		     grep ${query_1_status} | wc -l) -ne $replica_1 ] ||
+	      [ $(oc get pods | eval ${query_2} | awk '{ print $3 }' | \
+			 grep ${query_2_status} | wc -l) -ne $replica_2 ]; do
+
+	if [ $retry_up -lt 240 ]; then
+	    retry_up=$(($retry_up + 1))
+	    sleep 1
+	else
+	    convert::print_fail "kompose up has failed to bring the pods up\n"
+	    oc get pods
+	    exit 1
+	fi
+
+    done
+
+    # Wait
+    sleep 2
+
+    # If pods are up, print a success message
+    if [ $(oc get pods | eval ${query_1} | awk '{ print $3 }' | \
+		  grep ${query_1_status} | wc -l) -eq $replica_1 ] &&
+	   [ $(oc get pods | eval ${query_2} | awk '{ print $3 }' | \
+		      grep ${query_2_status} | wc -l) -eq $replica_2 ]; then
+	oc get pods
+	convert::print_pass "All pods are Running now. kompose up is successful."
+    fi
+}
+
+function convert::kompose_down_check () {
+    # Checks if the pods have been successfully deleted
+    # with 'kompose down'.
+    # Usage: convert::kompose_down_check <num_of_pods>
+
+    local retry_down=0
+    local pod_count=$1
+
+    convert::print_msg "Waiting for the pods to go down ..."
+
+    while [ $(oc get pods | wc -l ) != 0 ] &&
+	  [ $(oc get pods | grep -v deploy | grep 'Terminating' | wc -l ) != $pod_count ]; do
+	if [ $retry_down -lt 120 ]; then
+	    retry_down=$(($retry_down + 1))
+	    sleep 1
+	else
+	    convert::print_fail "kompose down has failed\n"
+	    oc get pods
+	    exit 1
+	fi
+    done
+
+    # Wait
+    sleep 2
+
+    # Print a message if all the pods are down
+    if [ $(oc get pods | wc -l ) == 0 ] ||
+       [ $(oc get pods | grep -v deploy | grep 'Terminating' | wc -l ) == $pod_count ]; then
+	convert::print_pass "All pods are down now. kompose down successful.\n"
+	oc get pods
+    fi
+}
+
+function convert::oc_cleanup () {
+    oc delete bc,rc,rs,svc,is,dc,deploy,ds,builds,route --all > /dev/null
+}
+
+function convert::oc_check_route () {
+    local route_key=$1
+    if [ $route_key == 'true' ]; then
+	route_key='xip.io'
+    fi
+
+    if [ $(oc get route | grep ${route_key} | wc -l ) -gt 0 ]; then
+	convert::print_pass "Route *.${route_key} has been exposed"
+    else
+	convert::print_fail "Route *.${route_key} has not been exposed\n"
+    fi
+
+    echo ""
+    oc get route
+}
+
+function convert::kompose_up () {
+    # Function for running 'kompose up'
+    # Usage: convert::kompose_up <docker_compose_file>
+    local compose_file=$1
+    convert::print_msg "Running kompose up ..."
+    kompose --provider=openshift --emptyvols -f $compose_file up
+    exit_status=$?
+
+    if [ $exit_status -ne 0 ]; then
+	convert::print_fail "kompose up has failed\n"
+	exit 1
+    fi
+}
+
+
+function convert::kompose_down () {
+    # Function for running 'kompose down'
+    # Usage: convert::kompose_down <docker_compose_file>
+    local compose_file=$1
+    convert::print_msg "Running kompose down ..."
+    kompose --provider=openshift -f $compose_file down
+    exit_status=$?
+
+    if [ $exit_status -ne 0 ]; then
+	convert::print_fail "kompose down has failed\n"
+	exit 1
+    fi
+}

--- a/script/test_in_openshift/run.sh
+++ b/script/test_in_openshift/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test case for kompose up/down with etherpad
+
+KOMPOSE_ROOT=$(readlink -f $(dirname "${BASH_SOURCE}")/../../..)
+source $KOMPOSE_ROOT/kompose/script/test/cmd/lib.sh
+source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
+openshift_exit_status=0
+
+convert::start_test "Functional tests on OpenShift"
+
+if [[ -n "${TRAVIS}" ]]; then
+    install_oc_client
+fi
+
+if [ -z $(whereis oc | awk '{ print $2 }') ]; then
+    convert::print_fail "Please install the oc binary to run tests\n"
+    exit 1
+fi
+
+convert::oc_cluster_up
+
+for test_case in $KOMPOSE_ROOT/script/test_in_openshift/tests/*; do
+    $test_case; exit_status=$?
+    if [ $exit_status -ne 0 ]; then
+	openshift_exit_status=1
+    fi
+    convert::oc_cleanup
+done
+
+convert::oc_cluster_down
+
+exit $openshift_exit_status

--- a/script/test_in_openshift/tests/buildconfig.sh
+++ b/script/test_in_openshift/tests/buildconfig.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test case for buildconfig on kompose
+
+KOMPOSE_ROOT=$(readlink -f $(dirname "${BASH_SOURCE}")/../../..)
+source $KOMPOSE_ROOT/script/test/cmd/lib.sh
+source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
+
+convert::print_msg "Testing buildconfig on kompose"
+
+docker_compose_file="${KOMPOSE_ROOT}/examples/buildconfig/docker-compose.yml"
+
+# Run kompose up
+convert::kompose_up $docker_compose_file
+
+# Check if the pods are up.
+convert::kompose_up_check -p foo
+
+# Kompose down for buildconfig fails being tracked at #382
+# convert::kompose_down $docker_compose_file
+
+# convert::kompose_down_check 2

--- a/script/test_in_openshift/tests/entrypoint-command.sh
+++ b/script/test_in_openshift/tests/entrypoint-command.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+KOMPOSE_ROOT=$(readlink -f $(dirname "${BASH_SOURCE}")/../../..)
+source $KOMPOSE_ROOT/script/test/cmd/lib.sh
+source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
+
+convert::print_msg "Running tests with entrypoint/command option"
+
+docker_compose_file="${KOMPOSE_ROOT}/script/test_in_openshift/compose-files/docker-compose-command.yml"
+
+# Run kompose up
+convert::kompose_up $docker_compose_file
+
+convert::kompose_up_check -p 'base1 base2'
+
+# Run Kompose down
+convert::kompose_down $docker_compose_file
+
+convert::kompose_down_check 2
+

--- a/script/test_in_openshift/tests/etherpad.sh
+++ b/script/test_in_openshift/tests/etherpad.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test case for kompose up/down with etherpad
+
+KOMPOSE_ROOT=$(readlink -f $(dirname "${BASH_SOURCE}")/../../..)
+source $KOMPOSE_ROOT/script/test/cmd/lib.sh
+source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
+
+convert::print_msg "Testing kompose up/down with etherpad docker-compose file"
+
+# Env variables for etherpad
+export $(cat ${KOMPOSE_ROOT}/script/test/fixtures/etherpad/envs)
+
+docker_compose_file="${KOMPOSE_ROOT}/script/test/fixtures/etherpad/docker-compose.yml"
+
+# Run kompose up
+convert::kompose_up $docker_compose_file
+
+# Check if the pods are up
+convert::kompose_up_check -p "etherpad mariadb"
+
+# Run Kompose down
+convert::kompose_down $docker_compose_file
+
+convert::kompose_down_check 2

--- a/script/test_in_openshift/tests/redis-replica-2.sh
+++ b/script/test_in_openshift/tests/redis-replica-2.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test case for checking replicas option with kompose
+
+KOMPOSE_ROOT=$(readlink -f $(dirname "${BASH_SOURCE}")/../../..)
+source $KOMPOSE_ROOT/script/test/cmd/lib.sh
+source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
+
+convert::print_msg "Running tests for replica option"
+
+# Run kompose up
+kompose --provider=openshift --emptyvols --replicas 2 -f ${KOMPOSE_ROOT}/examples/docker-compose-counter.yaml up; exit_status=$?
+
+if [ $exit_status -ne 0 ]; then
+    convert::print_fail "kompose up has failed"
+    exit 1
+fi
+
+
+# Check if redis and web pods are up. Replica count: 2
+convert::kompose_up_check -p "redis web" -r 2
+
+# Run Kompose down
+convert::kompose_down ${KOMPOSE_ROOT}/examples/docker-compose-counter.yaml
+
+convert::kompose_down_check 4


### PR DESCRIPTION
Adding kompose up/down tests for openshift as part of #323.

The script runs kompose up/down using etherpad docker-compose file with `oc cluster up`. 