### PR TITLE
Remove extend from unused keys, add to conversion doc

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -18,7 +18,7 @@ This document outlines all the conversion details regarding `docker-compose.yaml
 | env_file |  | N |  |  |
 | environment |  | Y | [Pod.Spec.Container.Env](https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_envvar) |  |
 | expose |  | Y | [Service.Spec.Ports](https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_containerport) |  |
-| extends | v2 | N |  |  |
+| extends | v2 | Y |  | Extends by utilizing the same image supplied |
 | external_links |  | N |  |  |
 | extra_hosts |  | N |  |  |
 | group_add |  | N |  |  |

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -59,7 +59,6 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 		"DNSSearch":     false,
 		"DomainName":    false,
 		"EnvFile":       false,
-		"Extends":       false,
 		"ExternalLinks": false,
 		"ExtraHosts":    false,
 		"Hostname":      false,


### PR DESCRIPTION
This removes the "unsupported" extends from the list (since we actually
support) as well as add a clarificiation on the conversion.md document.

Closes https://github.com/kubernetes-incubator/kompose/issues/475
Closes https://github.com/kubernetes-incubator/kompose/issues/493