### PR TITLE
travis-ci: send report to coveralls in after_success section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@
 dist : trusty
 sudo: required
 
-
 language: go
 
 # make this also work for forks
 go_import_path: github.com/kubernetes-incubator/kompose
-
 
 go:
   - 1.6
@@ -21,12 +19,13 @@ before_install:
   - go get github.com/sgotti/glide-vc
   - go get github.com/golang/lint/golint
 
-
 install:
   - true
 
 script:
   - make test
+
+after_success:
   # gover collects all .coverprofile files and saves it to one file gover.coverprofile
   - gover
   - goveralls -coverprofile=gover.coverprofile -service=travis-ci


### PR DESCRIPTION
Connection to coveralls.io sometimes fails and its marking tests as fail
even then are OK. Exit code from after_success do not affects build
result.