### PR TITLE
Added dockerfile key support

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -84,6 +84,7 @@ type ServiceConfig struct {
 	Tty           bool                `compose:"tty" bundle:""`
 	MemLimit      yaml.MemStringorInt `compose:"mem_limit" bundle:""`
 	TmpFs         []string            `compose:"tmpfs" bundle:""`
+	Dockerfile    string              `compose:"dockerfile" bundle:""`
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -76,7 +76,6 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 		"Uts":           false,
 		"ReadOnly":      false,
 		"Ulimits":       false,
-		"Dockerfile":    false,
 		"Net":           false,
 		"Sysctls":       false,
 		"Networks":      false, // there are special checks for Network in checkUnsupportedKey function
@@ -321,6 +320,7 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 		serviceConfig.ContainerName = composeServiceConfig.ContainerName
 		serviceConfig.Command = composeServiceConfig.Entrypoint
 		serviceConfig.Args = composeServiceConfig.Command
+		serviceConfig.Dockerfile = composeServiceConfig.Build.Dockerfile
 
 		envs := loadEnvVars(composeServiceConfig.Environment)
 		serviceConfig.Environment = envs

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -200,7 +200,9 @@ func initBuildConfig(name string, service kobject.ServiceConfig, composeFileDir 
 					ContextDir: contextDir,
 				},
 				Strategy: buildapi.BuildStrategy{
-					DockerStrategy: &buildapi.DockerBuildStrategy{},
+					DockerStrategy: &buildapi.DockerBuildStrategy{
+						DockerfilePath: service.Dockerfile,
+					},
 				},
 				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -290,7 +290,8 @@ func TestInitBuildConfig(t *testing.T) {
 	repo := "https://git.test.com/org/repo"
 	branch := "somebranch"
 	sc := kobject.ServiceConfig{
-		Build: "./build",
+		Build:      "./build",
+		Dockerfile: "Dockerfile-alternate",
 	}
 	bc, err := initBuildConfig(serviceName, sc, composeFileDir, repo, branch)
 	if err != nil {
@@ -305,6 +306,7 @@ func TestInitBuildConfig(t *testing.T) {
 		"Assert buildconfig source git Ref":     {bc.Spec.CommonSpec.Source.Git.Ref, branch},
 		"Assert buildconfig source context dir": {bc.Spec.CommonSpec.Source.ContextDir, "a/build"},
 		"Assert buildconfig output name":        {bc.Spec.CommonSpec.Output.To.Name, serviceName + ":latest"},
+		"Assert buildconfig dockerfilepath":     {bc.Spec.CommonSpec.Strategy.DockerStrategy.DockerfilePath, "Dockerfile-alternate"},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
Fixes #486
This commit will add `dockerfilepath` key under Dockerstratergy in Buildconfig.
dockerfilepath allow us to use dockerfiles which are named different than `Dockerfile`