### PR TITLE
Ignore the /bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Ignore compiled Kompose files
 kompose
+bin
 
 #
 # GO SPECIFIC


### PR DESCRIPTION
Bin folder is used for binary generation. Ignore it.