### PR TITLE
Propagate underscore into valid name

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -374,7 +374,10 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 		serviceConfig.Tty = composeServiceConfig.Tty
 		serviceConfig.MemLimit = composeServiceConfig.MemLimit
 		serviceConfig.TmpFs = composeServiceConfig.Tmpfs
-		komposeObject.ServiceConfigs[name] = serviceConfig
+		komposeObject.ServiceConfigs[normalizeServiceNames(name)] = serviceConfig
+		if normalizeServiceNames(name) != name {
+			log.Infof("Service name in docker-compose has been changed from %q to %q", name, normalizeServiceNames(name))
+		}
 	}
 
 	return komposeObject, nil

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -637,7 +637,7 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 	if !opt.EmptyVols {
 		pvcStr = " and PersistentVolumeClaims "
 	}
-	fmt.Println("We are going to create Kubernetes Deployments, Services" + pvcStr + "for your Dockerized application. \n" +
+	log.Info("We are going to create Kubernetes Deployments, Services" + pvcStr + "for your Dockerized application. " +
 		"If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. \n")
 
 	client, namespace, err := k.GetKubernetesClient()


### PR DESCRIPTION
Now we can provide service name with `_` in docker-compose files and they will by converted as `-` in the generated artifacts by kompose eg, if the service name in docker-compose file is "foo_bar" then it will be converted into "foo-bar" in the generated artifacts.

`docker-compose.yml` containing `_` in service name.
```yaml
version: "2"
services:
  web_service:
    image: tuna/docker-counter23:latest
    ports:
      - "5000:5000"
    links:
      - redis_service
  redis_service:
    image: redis:latest
    ports:
      - "6379"
````
```bash
$ kompose up
INFO[0000] Service name in docker-compose has been changed from "redis_service" to "redis-service" 
INFO[0000] Service name in docker-compose has been changed from "web_service" to "web-service" 

We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. 
If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. 

INFO[0000] Successfully created Service: redis-service  
INFO[0000] Successfully created Service: web-service    
INFO[0000] Successfully created Deployment: redis-service 
INFO[0000] Successfully created Deployment: web-service 

Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods,pvc' for details.
```

`docker-compose.yml` without `_` in service name.
```yaml
version: "2"
services:
  web:
    image: tuna/docker-counter23:latest
    ports:
      - "5000:5000"
    links:
      - redis
  redis:
    image: redis:latest
    ports:
      - "6379"
````

```bash
$ kompose up
We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. 
If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. 

INFO[0000] Successfully created Service: redis          
INFO[0000] Successfully created Service: web            
INFO[0000] Successfully created Deployment: redis       
INFO[0000] Successfully created Deployment: web         

Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods,pvc' for details.
```
cc: @kadel @cdrage 
Fixes: #420 