### PR TITLE
add missing 'io.kompose.service' label to Route and Ingress

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -208,7 +208,8 @@ func (k *Kubernetes) initIngress(name string, service kobject.ServiceConfig, por
 			APIVersion: "extensions/v1beta1",
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: transformer.ConfigLabels(name),
 		},
 		Spec: extensions.IngressSpec{
 			Rules: []extensions.IngressRule{

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -280,7 +280,8 @@ func (o *OpenShift) initRoute(name string, service kobject.ServiceConfig, port i
 			APIVersion: "v1",
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: transformer.ConfigLabels(name),
 		},
 		Spec: routeapi.RouteSpec{
 			Port: &routeapi.RoutePort{

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
@@ -146,7 +146,10 @@
       "apiVersion": "extensions/v1beta1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "rules": [

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
@@ -138,7 +138,10 @@
       "apiVersion": "extensions/v1beta1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "rules": [

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
@@ -146,7 +146,10 @@
       "apiVersion": "extensions/v1beta1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "rules": [

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
@@ -138,7 +138,10 @@
       "apiVersion": "extensions/v1beta1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "rules": [

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json
@@ -256,7 +256,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "host": "batman.example.com",

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname.json
@@ -248,7 +248,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "host": "batman.example.com",

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-true-multiple-ports.json
@@ -256,7 +256,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "host": "",

--- a/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json
+++ b/script/test/fixtures/expose-service/provider-files/openshift-expose-true.json
@@ -248,7 +248,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "web",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
       },
       "spec": {
         "host": "",


### PR DESCRIPTION
This was caussing 'kompose down' not to delete Route and Ingress

fixes #510 