### PR TITLE
Ignore Docker Compose files in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Ignore compiled Kompose files
 kompose
 bin
+docker-compose.yaml
+docker-compose.yml
 
 #
 # GO SPECIFIC


### PR DESCRIPTION
When developing Kompose, it's common to have the Docker Compose file in
the root directory.

Adding it to gitignore ignores it for any changes that could be
committed / pushed by accident.