### PR TITLE
Added support for different namespaces

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -26,7 +26,8 @@ import (
 
 // TODO: comment
 var (
-	DownOpt kobject.ConvertOptions
+	DownNamespace string
+	DownOpt       kobject.ConvertOptions
 )
 
 var downCmd = &cobra.Command{
@@ -37,8 +38,10 @@ var downCmd = &cobra.Command{
 
 		// Create the Convert options.
 		DownOpt = kobject.ConvertOptions{
-			InputFiles: GlobalFiles,
-			Provider:   strings.ToLower(GlobalProvider),
+			InputFiles:      GlobalFiles,
+			Provider:        strings.ToLower(GlobalProvider),
+			Namespace:       DownNamespace,
+			IsNamespaceFlag: cmd.Flags().Lookup("namespace").Changed,
 		}
 
 		// Validate before doing anything else.
@@ -50,5 +53,6 @@ var downCmd = &cobra.Command{
 }
 
 func init() {
+	downCmd.Flags().StringVar(&DownNamespace, "namespace", "default", " Specify Namespace to deploy your application")
 	RootCmd.AddCommand(downCmd)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -29,6 +29,7 @@ var (
 	UpReplicas     int
 	UpEmptyVols    bool
 	UpInsecureRepo bool
+	UpNamespace    string
 	UpOpt          kobject.ConvertOptions
 )
 
@@ -44,7 +45,9 @@ var upCmd = &cobra.Command{
 			InputFiles:         GlobalFiles,
 			Provider:           strings.ToLower(GlobalProvider),
 			EmptyVols:          UpEmptyVols,
+			Namespace:          UpNamespace,
 			InsecureRepository: UpInsecureRepo,
+			IsNamespaceFlag:    cmd.Flags().Lookup("namespace").Changed,
 		}
 
 		// Validate before doing anything else.
@@ -59,5 +62,6 @@ func init() {
 	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
 	upCmd.Flags().IntVar(&UpReplicas, "replicas", 1, "Specify the number of replicas generated")
 	upCmd.Flags().BoolVar(&UpInsecureRepo, "insecure-repository", false, "Use an insecure Docker repository for OpenShift ImageStream")
+	upCmd.Flags().StringVar(&UpNamespace, "namespace", "default", "Specify Namespace to deploy your application")
 	RootCmd.AddCommand(upCmd)
 }

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -48,10 +48,12 @@ type ConvertOptions struct {
 	InputFiles                  []string
 	OutFile                     string
 	Provider                    string
+	Namespace                   string
 	IsDeploymentFlag            bool
 	IsDaemonSetFlag             bool
 	IsReplicationControllerFlag bool
 	IsDeploymentConfigFlag      bool
+	IsNamespaceFlag             bool
 }
 
 // ServiceConfig holds the basic struct of a container

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -640,10 +640,16 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 	log.Info("We are going to create Kubernetes Deployments, Services" + pvcStr + "for your Dockerized application. " +
 		"If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. \n")
 
-	client, namespace, err := k.GetKubernetesClient()
+	client, ns, err := k.GetKubernetesClient()
+	namespace := ns
+	if opt.IsNamespaceFlag {
+		namespace = opt.Namespace
+	}
 	if err != nil {
 		return err
 	}
+
+	log.Infof("Deploying application in %q namespace", namespace)
 
 	for _, v := range objects {
 		switch t := v.(type) {
@@ -700,11 +706,18 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 		return errorList
 	}
 
-	client, namespace, err := k.GetKubernetesClient()
+	client, ns, err := k.GetKubernetesClient()
+	namespace := ns
+	if opt.IsNamespaceFlag {
+		namespace = opt.Namespace
+	}
+
 	if err != nil {
 		errorList = append(errorList, err)
 		return errorList
 	}
+
+	log.Infof("Deleting application in %q namespace", namespace)
 
 	for _, v := range objects {
 		label := labels.SelectorFromSet(labels.Set(map[string]string{transformer.Selector: v.(meta.Object).GetName()}))


### PR DESCRIPTION
Now we can deploy application in different namespaces using the `--namespace=<value>` flag with `kompose up` and `kompose down`. The `--namepace` flag will deploy the application in that particular `namespace` if, exist.

`docker-compose` file used.
```yaml
version: "2"
services:
  web:
    image: tuna/docker-counter23:latest
    ports:
      - "5000:5000"
    links:
      - redis
  redis:
    image: redis:latest
    ports:
      - "6379"
```
Current `namespaces` in k8s cluster
```bash
$ kubectl get namespace 
NAME          STATUS    AGE
default       Active    3m
development   Active    3m
kube-system   Active    3m
```

Deploy application in `namespace=development`
```bash
$ kompose up --namespace=development
We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. 
If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. 

INFO[0000] Deploying application in "development" namespace
 
INFO[0000] Successfully created Service: redis          
INFO[0000] Successfully created Service: web            
INFO[0000] Successfully created Deployment: redis       
INFO[0000] Successfully created Deployment: web         

Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods,pvc' for details.
```

Verify application been deployed in the `namespace=development` correctly
```bash 
$ kubectl get deployment,svc,pods,pvc --namespace=development
NAME                        DESIRED      CURRENT             UP-TO-DATE   AVAILABLE   AGE
redis                       1            1                   1            0           2m
web                         1            1                   1            0           2m
NAME                        CLUSTER-IP   EXTERNAL-IP         PORT(S)      AGE
redis                       10.0.0.110   <none>              6379/TCP     2m
web                         10.0.0.55    <none>              5000/TCP     2m
NAME                        READY        STATUS              RESTARTS     AGE
mlbparks-3930800586-mblgc   0/1          Terminating         0            4m
redis-741327525-om0xc       0/1          ContainerCreating   0            2m
web-519030457-28arz         0/1          ContainerCreating   0            2m
```

Delete the application that has been deployed in the `namespace=development`
```bash
$ kompose down --namespace=development
INFO[0000] Deleting application from "development" namespace
 
INFO[0000] Successfully deleted Service: redis          
INFO[0000] Successfully deleted Service: web            
INFO[0003] Successfully deleted Deployment: redis       
INFO[0006] Successfully deleted Deployment: web  
```

Fixes: #473 

CC: @kadel @cdrage @containscafeine @surajssd 