### PR TITLE
Fix typo in replicas and organize flags

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -103,10 +103,10 @@ func init() {
 
 	// OpenShift only
 	convertCmd.Flags().BoolVar(&ConvertDeploymentConfig, "deployment-config", true, "Generate an OpenShift deploymentconfig object")
-	convertCmd.Flags().MarkHidden("deployment-config")
 	convertCmd.Flags().StringVar(&ConvertBuildRepo, "build-repo", "", "Specify source repository for buildconfig (default remote origin)")
-	convertCmd.Flags().MarkHidden("build-repo")
 	convertCmd.Flags().StringVar(&ConvertBuildBranch, "build-branch", "", "Specify repository branch to use for buildconfig (default master)")
+	convertCmd.Flags().MarkHidden("deployment-config")
+	convertCmd.Flags().MarkHidden("build-repo")
 	convertCmd.Flags().MarkHidden("build-branch")
 
 	// Standard between the two

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -54,7 +54,7 @@ var upCmd = &cobra.Command{
 }
 
 func init() {
-	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")
-	upCmd.Flags().IntVar(&UpReplicas, "replicas", 1, "Specify the number of repliaces in the generate resource spec")
+	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
+	upCmd.Flags().IntVar(&UpReplicas, "replicas", 1, "Specify the number of replicas generated")
 	RootCmd.AddCommand(upCmd)
 }


### PR DESCRIPTION
Fixes a typo in the `--replicas` command as well as changes up some
grammar and moves the 'markashidden' flag values elsewhere.