### PR TITLE
Update contributing doc for reviewing, update owners file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,12 @@ Contact one of the [OWNERS](OWNERS) on Slack to access the appropriate CLA and i
 ### Contributing A Patch
 
 1. Submit an issue describing your proposed change to the repo in question.
-1. The [repo owners](OWNERS) will respond to your issue promptly.
-1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
-1. Fork the desired repo, develop and test your code changes.
-1. Submit a pull request.
+2. The [repo owners](OWNERS) will respond to your issue promptly.
+3. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
+4. Fork the desired repo, develop and test your code changes.
+5. Submit a pull request.
+
+Note: Code-related PR's require two ACK's / LGTM's from a maintainer while doc-related PR's require only one
 
 ### Adding dependencies
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,20 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+# https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
-assignees:
-  - runseb
-  - ngtuna
+reviewers:
+  - cdrage
+  - containscafeine
   - janetkuo
   - kadel 
+  - ngtuna
+  - runseb
+  - surajssd
+
+approvers:
+  - cdrage
+  - containscafeine
+  - janetkuo
+  - kadel 
+  - ngtuna
+  - runseb
   - surajssd


### PR DESCRIPTION
Owners file currently isn't being used (unless we have the Kubernetes
bot in-use), however, it needed a well-overdue update.

I've gone ahead and updated the CONTRIBUTING.md doc to add the change
that it requires *two* reviews for a code-review and one for a doc
review.