### PR TITLE
new take on "Kompose will keep trying its job #477"

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -287,7 +287,9 @@ func Down(opt kobject.ConvertOptions) {
 	//Remove deployed application
 	errUndeploy := t.Undeploy(komposeObject, opt)
 	if errUndeploy != nil {
-		log.Fatalf("Error while deleting application: %s", errUndeploy)
+		for _, err = range errUndeploy {
+			log.Fatalf("Error while deleting application: %s", err)
+		}
 	}
 
 }

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -695,14 +695,15 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 	var errorList []error
 	//Convert komposeObject
 	objects, err := k.Transform(komposeObject, opt)
-
 	if err != nil {
 		errorList = append(errorList, err)
+		return errorList
 	}
 
 	client, namespace, err := k.GetKubernetesClient()
 	if err != nil {
 		errorList = append(errorList, err)
+		return errorList
 	}
 
 	for _, v := range objects {
@@ -715,18 +716,20 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			deployment, err := client.Deployments(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range deployment.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpDeployment, err := kubectl.ReaperFor(extensions.Kind("Deployment"), client)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					//FIXME: gracePeriod is nil
 					err = rpDeployment.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
-
+						break
 					}
 					log.Infof("Successfully deleted Deployment: %s", t.Name)
 
@@ -738,17 +741,20 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			svc, err := client.Services(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range svc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpService, err := kubectl.ReaperFor(api.Kind("Service"), client)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					//FIXME: gracePeriod is nil
 					err = rpService.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Service: %s", t.Name)
 
@@ -760,12 +766,14 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			pvc, err := client.PersistentVolumeClaims(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range pvc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = client.PersistentVolumeClaims(namespace).Delete(t.Name)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
 				}
@@ -782,6 +790,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			ingress, err := client.Ingress(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range ingress.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
@@ -789,6 +798,7 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 					err = client.Ingress(namespace).Delete(t.Name, ingDeleteOptions)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Ingress: %s", t.Name)
 				}
@@ -805,11 +815,13 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 					rpPod, err := kubectl.ReaperFor(api.Kind("Pod"), client)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					//FIXME: gracePeriod is nil
 					err = rpPod.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Pod: %s", t.Name)
 				}

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -691,17 +691,18 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 }
 
 // Undeploy deletes deployed objects from Kubernetes cluster
-func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error {
+func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) []error {
+	var errorList []error
 	//Convert komposeObject
 	objects, err := k.Transform(komposeObject, opt)
 
 	if err != nil {
-		return errors.Wrap(err, "k.Transform failed")
+		errorList = append(errorList, err)
 	}
 
 	client, namespace, err := k.GetKubernetesClient()
 	if err != nil {
-		return err
+		errorList = append(errorList, err)
 	}
 
 	for _, v := range objects {
@@ -713,20 +714,22 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			//delete deployment
 			deployment, err := client.Deployments(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range deployment.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpDeployment, err := kubectl.ReaperFor(extensions.Kind("Deployment"), client)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					//FIXME: gracePeriod is nil
 					err = rpDeployment.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
+
 					}
 					log.Infof("Successfully deleted Deployment: %s", t.Name)
+
 				}
 			}
 
@@ -734,20 +737,21 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			//delete svc
 			svc, err := client.Services(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range svc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpService, err := kubectl.ReaperFor(api.Kind("Service"), client)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					//FIXME: gracePeriod is nil
 					err = rpService.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Service: %s", t.Name)
+
 				}
 			}
 
@@ -755,13 +759,13 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			// delete pvc
 			pvc, err := client.PersistentVolumeClaims(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range pvc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = client.PersistentVolumeClaims(namespace).Delete(t.Name)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
 				}
@@ -777,14 +781,14 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			}
 			ingress, err := client.Ingress(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range ingress.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 
 					err = client.Ingress(namespace).Delete(t.Name, ingDeleteOptions)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Ingress: %s", t.Name)
 				}
@@ -794,23 +798,24 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 			//delete pod
 			pod, err := client.Pods(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range pod.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpPod, err := kubectl.ReaperFor(api.Kind("Pod"), client)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					//FIXME: gracePeriod is nil
 					err = rpPod.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Pod: %s", t.Name)
 				}
 			}
 		}
 	}
-	return nil
+
+	return errorList
 }

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -502,14 +502,17 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 
 	if err != nil {
 		errorList = append(errorList, err)
+		return errorList
 	}
 	oclient, err := o.getOpenShiftClient()
 	if err != nil {
 		errorList = append(errorList, err)
+		return errorList
 	}
 	kclient, namespace, err := o.GetKubernetesClient()
 	if err != nil {
 		errorList = append(errorList, err)
+		return errorList
 	}
 
 	for _, v := range objects {
@@ -522,12 +525,14 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			imageStream, err := oclient.ImageStreams(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range imageStream.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = oclient.ImageStreams(namespace).Delete(t.Name)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted ImageStream: %s", t.Name)
 				}
@@ -538,12 +543,14 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			buildConfig, err := oclient.BuildConfigs(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range buildConfig.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err := oclient.BuildConfigs(namespace).Delete(t.Name)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted BuildConfig: %s", t.Name)
 				}
@@ -554,6 +561,7 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			deploymentConfig, err := oclient.DeploymentConfigs(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range deploymentConfig.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
@@ -561,6 +569,7 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 					err := dcreaper.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted DeploymentConfig: %s", t.Name)
 				}
@@ -571,17 +580,20 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			svc, err := kclient.Services(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range svc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpService, err := kubectl.ReaperFor(api.Kind("Service"), kclient)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					//FIXME: gracePeriod is nil
 					err = rpService.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Service: %s", t.Name)
 				}
@@ -592,12 +604,14 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			pvc, err := kclient.PersistentVolumeClaims(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range pvc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = kclient.PersistentVolumeClaims(namespace).Delete(t.Name)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
 				}
@@ -608,12 +622,14 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			route, err := oclient.Routes(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range route.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = oclient.Routes(namespace).Delete(t.Name)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Route: %s", t.Name)
 				}
@@ -624,18 +640,21 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			pod, err := kclient.Pods(namespace).List(options)
 			if err != nil {
 				errorList = append(errorList, err)
+				break
 			}
 			for _, l := range pod.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpPod, err := kubectl.ReaperFor(api.Kind("Pod"), kclient)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 
 					//FIXME: gracePeriod is nil
 					err = rpPod.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
 						errorList = append(errorList, err)
+						break
 					}
 					log.Infof("Successfully deleted Pod: %s", t.Name)
 

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -495,20 +495,21 @@ func (o *OpenShift) Deploy(komposeObject kobject.KomposeObject, opt kobject.Conv
 }
 
 //Undeploy removes deployed artifacts from OpenShift cluster
-func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error {
+func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) []error {
+	var errorList []error
 	//Convert komposeObject
 	objects, err := o.Transform(komposeObject, opt)
 
 	if err != nil {
-		return errors.Wrap(err, "o.Transform failed")
+		errorList = append(errorList, err)
 	}
 	oclient, err := o.getOpenShiftClient()
 	if err != nil {
-		return err
+		errorList = append(errorList, err)
 	}
 	kclient, namespace, err := o.GetKubernetesClient()
 	if err != nil {
-		return err
+		errorList = append(errorList, err)
 	}
 
 	for _, v := range objects {
@@ -520,13 +521,13 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			//delete imageStream
 			imageStream, err := oclient.ImageStreams(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range imageStream.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = oclient.ImageStreams(namespace).Delete(t.Name)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted ImageStream: %s", t.Name)
 				}
@@ -536,13 +537,13 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			//options := api.ListOptions{LabelSelector: label}
 			buildConfig, err := oclient.BuildConfigs(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range buildConfig.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err := oclient.BuildConfigs(namespace).Delete(t.Name)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted BuildConfig: %s", t.Name)
 				}
@@ -552,14 +553,14 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			// delete deploymentConfig
 			deploymentConfig, err := oclient.DeploymentConfigs(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range deploymentConfig.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					dcreaper := deploymentconfigreaper.NewDeploymentConfigReaper(oclient, kclient)
 					err := dcreaper.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted DeploymentConfig: %s", t.Name)
 				}
@@ -569,18 +570,18 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			//delete svc
 			svc, err := kclient.Services(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range svc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpService, err := kubectl.ReaperFor(api.Kind("Service"), kclient)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					//FIXME: gracePeriod is nil
 					err = rpService.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Service: %s", t.Name)
 				}
@@ -590,13 +591,13 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			// delete pvc
 			pvc, err := kclient.PersistentVolumeClaims(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range pvc.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = kclient.PersistentVolumeClaims(namespace).Delete(t.Name)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted PersistentVolumeClaim: %s", t.Name)
 				}
@@ -606,13 +607,13 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			// delete route
 			route, err := oclient.Routes(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range route.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					err = oclient.Routes(namespace).Delete(t.Name)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Route: %s", t.Name)
 				}
@@ -622,23 +623,25 @@ func (o *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.Co
 			//delete pods
 			pod, err := kclient.Pods(namespace).List(options)
 			if err != nil {
-				return err
+				errorList = append(errorList, err)
 			}
 			for _, l := range pod.Items {
 				if reflect.DeepEqual(l.Labels, komposeLabel) {
 					rpPod, err := kubectl.ReaperFor(api.Kind("Pod"), kclient)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
+
 					//FIXME: gracePeriod is nil
 					err = rpPod.Stop(namespace, t.Name, TIMEOUT*time.Second, nil)
 					if err != nil {
-						return err
+						errorList = append(errorList, err)
 					}
 					log.Infof("Successfully deleted Pod: %s", t.Name)
+
 				}
 			}
 		}
 	}
-	return nil
+	return errorList
 }

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -28,5 +28,5 @@ type Transformer interface {
 	// Deploy deploys KomposeObject to provider
 	Deploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error
 	// Undeploy deletes/undeploys KomposeObject from provider
-	Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error
+	Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) []error
 }


### PR DESCRIPTION
This is reopening of #477 there were some issues that we forgot to address. 

Issue was that if it can't connect to cluster it panics.
Problem is that we continue after every error.
There should be return after some errors, and after every error in switch should be break so we don't 
try to get reaper using client which creation field or calling `Stop` on reaper that field to create.

I've added new commit on top of  original @surajnarwade's commit, so its easier to review.
Once we agreed that this is the way we wan't to do it we can squash it
