### PR TITLE
Moved cpu_shares and cpuset to unsupported keys

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -54,6 +54,8 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 		"CapAdd":        false,
 		"CapDrop":       false,
 		"CgroupParent":  false,
+		"CPUSet":        false,
+		"CPUShares":     false,
 		"Devices":       false,
 		"DependsOn":     false,
 		"DNS":           false,
@@ -359,9 +361,6 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 
 		// convert compose labels to annotations
 		serviceConfig.Annotations = map[string]string(composeServiceConfig.Labels)
-
-		serviceConfig.CPUSet = composeServiceConfig.CPUSet
-		serviceConfig.CPUShares = int64(composeServiceConfig.CPUShares)
 		serviceConfig.CPUQuota = int64(composeServiceConfig.CPUQuota)
 		serviceConfig.CapAdd = composeServiceConfig.CapAdd
 		serviceConfig.CapDrop = composeServiceConfig.CapDrop

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -49,8 +49,6 @@ func TestCreateService(t *testing.T) {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"abc": "def"},
-		CPUSet:        "cpu_set",            // not supported
-		CPUShares:     1,                    // not supported
 		CPUQuota:      1,                    // not supported
 		CapAdd:        []string{"cap_add"},  // not supported
 		CapDrop:       []string{"cap_drop"}, // not supported
@@ -95,8 +93,6 @@ func TestCreateServiceWithMemLimit(t *testing.T) {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"abc": "def"},
-		CPUSet:        "cpu_set",            // not supported
-		CPUShares:     1,                    // not supported
 		CPUQuota:      1,                    // not supported
 		CapAdd:        []string{"cap_add"},  // not supported
 		CapDrop:       []string{"cap_drop"}, // not supported
@@ -146,8 +142,6 @@ func TestCreateServiceWithServiceUser(t *testing.T) {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"kompose.service.type": "nodeport"},
-		CPUSet:        "cpu_set",            // not supported
-		CPUShares:     1,                    // not supported
 		CPUQuota:      1,                    // not supported
 		CapAdd:        []string{"cap_add"},  // not supported
 		CapDrop:       []string{"cap_drop"}, // not supported

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -45,8 +45,6 @@ func newServiceConfig() kobject.ServiceConfig {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"abc": "def"},
-		CPUSet:        "cpu_set",            // not supported
-		CPUShares:     1,                    // not supported
 		CPUQuota:      1,                    // not supported
 		CapAdd:        []string{"cap_add"},  // not supported
 		CapDrop:       []string{"cap_drop"}, // not supported

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -45,8 +45,6 @@ func newServiceConfig() kobject.ServiceConfig {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"abc": "def"},
-		CPUSet:        "cpu_set",            // not supported
-		CPUShares:     1,                    // not supported
 		CPUQuota:      1,                    // not supported
 		CapAdd:        []string{"cap_add"},  // not supported
 		CapDrop:       []string{"cap_drop"}, // not supported


### PR DESCRIPTION
Resolves #272 and #267

As there is no direct mapping of `cpushares` and `cpuset` to kubernetes,
it should not be read and should be moved to unsupported keys.