### PR TITLE
Support insecure registry and enhance parsing of image stream tag

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -38,6 +38,7 @@ var (
 	ConvertJSON                  bool
 	ConvertStdout                bool
 	ConvertEmptyVols             bool
+	ConvertInsecureRepo          bool
 	ConvertDeploymentConfig      bool
 	ConvertReplicas              int
 	ConvertOpt                   kobject.ConvertOptions
@@ -68,6 +69,7 @@ var convertCmd = &cobra.Command{
 			BuildBranch:                 ConvertBuildBranch,
 			CreateDeploymentConfig:      ConvertDeploymentConfig,
 			EmptyVols:                   ConvertEmptyVols,
+			InsecureRepository:          ConvertInsecureRepo,
 			IsDeploymentFlag:            cmd.Flags().Lookup("deployment").Changed,
 			IsDaemonSetFlag:             cmd.Flags().Lookup("daemon-set").Changed,
 			IsReplicationControllerFlag: cmd.Flags().Lookup("replication-controller").Changed,
@@ -101,9 +103,11 @@ func init() {
 
 	// OpenShift only
 	convertCmd.Flags().BoolVar(&ConvertDeploymentConfig, "deployment-config", true, "Generate an OpenShift deploymentconfig object")
+	convertCmd.Flags().BoolVar(&ConvertInsecureRepo, "insecure-repository", false, "Use an insecure Docker repository for OpenShift ImageStream")
 	convertCmd.Flags().StringVar(&ConvertBuildRepo, "build-repo", "", "Specify source repository for buildconfig (default remote origin)")
 	convertCmd.Flags().StringVar(&ConvertBuildBranch, "build-branch", "", "Specify repository branch to use for buildconfig (default master)")
 	convertCmd.Flags().MarkHidden("deployment-config")
+	convertCmd.Flags().MarkHidden("insecure-repository")
 	convertCmd.Flags().MarkHidden("build-repo")
 	convertCmd.Flags().MarkHidden("build-branch")
 
@@ -138,6 +142,7 @@ Resource Flags:
       --daemon-set               Generate a Kubernetes daemonset object
   -d, --deployment               Generate a Kubernetes deployment object
       --deployment-config        Generate an OpenShift deployment config object
+      --insecure-repository      Specify to use insecure docker repository while generating Openshift image stream object
       --replication-controller   Generate a Kubernetes replication controller object
 
 Flags:

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -26,9 +26,10 @@ import (
 
 // TODO: comment
 var (
-	UpReplicas  int
-	UpEmptyVols bool
-	UpOpt       kobject.ConvertOptions
+	UpReplicas     int
+	UpEmptyVols    bool
+	UpInsecureRepo bool
+	UpOpt          kobject.ConvertOptions
 )
 
 var upCmd = &cobra.Command{
@@ -39,10 +40,11 @@ var upCmd = &cobra.Command{
 
 		// Create the Convert options.
 		UpOpt = kobject.ConvertOptions{
-			Replicas:   UpReplicas,
-			InputFiles: GlobalFiles,
-			Provider:   strings.ToLower(GlobalProvider),
-			EmptyVols:  UpEmptyVols,
+			Replicas:           UpReplicas,
+			InputFiles:         GlobalFiles,
+			Provider:           strings.ToLower(GlobalProvider),
+			EmptyVols:          UpEmptyVols,
+			InsecureRepository: UpInsecureRepo,
 		}
 
 		// Validate before doing anything else.
@@ -56,5 +58,6 @@ var upCmd = &cobra.Command{
 func init() {
 	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
 	upCmd.Flags().IntVar(&UpReplicas, "replicas", 1, "Specify the number of replicas generated")
+	upCmd.Flags().BoolVar(&UpInsecureRepo, "insecure-repository", false, "Use an insecure Docker repository for OpenShift ImageStream")
 	RootCmd.AddCommand(upCmd)
 }

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -43,6 +43,7 @@ type ConvertOptions struct {
 	GenerateYaml                bool
 	GenerateJSON                bool
 	EmptyVols                   bool
+	InsecureRepository          bool
 	Replicas                    int
 	InputFiles                  []string
 	OutFile                     string


### PR DESCRIPTION
Add 2 enhancements for openshift:
	- support insecure docker registry for generation of openshift image stream
	    we add an import policy for the image stream tag by following instruction of the command argument
	- enhance parsing of image tag
	    current implementation doesn't support format like "myregistryhost:5000/fedora/httpd:version1.0". Enhance the parsing logic.