### PR TITLE
fix driver:local in prefixing volumes with current dir name

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -338,7 +338,8 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 
 		if composeServiceConfig.Volumes != nil {
 			for _, volume := range composeServiceConfig.Volumes.Volumes {
-				serviceConfig.Volumes = append(serviceConfig.Volumes, volume.String())
+				v := normalizeServiceNames(volume.String())
+				serviceConfig.Volumes = append(serviceConfig.Volumes, v)
 			}
 		}
 

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -176,6 +176,14 @@ convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/te
 # when kompose.service.expose="<hostname>" and multiple ports in docker compose file (first port should be selected)
 convert::expect_success "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose-service/compose-files/docker-compose-expose-hostname-multiple-ports.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/expose-service/provider-files/openshift-expose-hostname-multiple-ports.json"
 
+
+# Test the change in the service name
+# Kubernetes Test
+convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/service-name-change/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/service-name-change/output-k8s.json" "Unsupported root level volumes key - ignoring"
+# Openshift Test
+convert::expect_success_and_warning "kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/service-name-change/docker-compose.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/service-name-change/output-os.json" "Unsupported root level volumes key - ignoring"
+
+
 ######
 # Test the output file behavior of kompose convert
 # Default behavior without -o

--- a/script/test/fixtures/service-name-change/docker-compose.yml
+++ b/script/test/fixtures/service-name-change/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2'
+services:
+  mariadb:
+    image: 'bitnami/mariadb:latest'
+    volumes:
+      - 'mariadb-data:/bitnami/mariadb'
+    environment:
+      - MARIADB_USER=bn_wordpress
+      - MARIADB_DATABASE=bitnami_wordpress
+      - ALLOW_EMPTY_PASSWORD=yes
+  wordpress:
+    image: 'bitnami/wordpress:latest'
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - 'wordpress-data:/bitnami/wordpress'
+      - 'apache-data:/bitnami/apache'
+      - 'php-data:/bitnami/php'
+    depends_on:
+      - mariadb
+    environment:
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT=3306
+      - WORDPRESS_DATABASE_USER=bn_wordpress
+      - WORDPRESS_DATABASE_NAME=bitnami_wordpress
+      - ALLOW_EMPTY_PASSWORD=yes
+volumes:
+  mariadb-data:
+    driver: local
+  wordpress-data:
+    driver: local
+  apache-data:
+    driver: local
+  php-data:
+    driver: local

--- a/script/test/fixtures/service-name-change/output-k8s.json
+++ b/script/test/fixtures/service-name-change/output-k8s.json
@@ -1,0 +1,311 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mariadb"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "mariadb"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          },
+          {
+            "name": "443",
+            "port": 443,
+            "targetPort": 443
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "mariadb"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "servicenamechange-mariadb-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-mariadb-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": "bitnami/mariadb:latest",
+                "env": [
+                  {
+                    "name": "MARIADB_USER",
+                    "value": "bn_wordpress"
+                  },
+                  {
+                    "name": "MARIADB_DATABASE",
+                    "value": "bitnami_wordpress"
+                  },
+                  {
+                    "name": "ALLOW_EMPTY_PASSWORD",
+                    "value": "yes"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "servicenamechange-mariadb-data",
+                    "mountPath": "/bitnami/mariadb"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-mariadb-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-mariadb-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "wordpress"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "servicenamechange-wordpress-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-wordpress-data"
+                }
+              },
+              {
+                "name": "servicenamechange-apache-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-apache-data"
+                }
+              },
+              {
+                "name": "servicenamechange-php-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-php-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "wordpress",
+                "image": "bitnami/wordpress:latest",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  },
+                  {
+                    "containerPort": 443
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MARIADB_HOST",
+                    "value": "mariadb"
+                  },
+                  {
+                    "name": "MARIADB_PORT",
+                    "value": "3306"
+                  },
+                  {
+                    "name": "WORDPRESS_DATABASE_USER",
+                    "value": "bn_wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DATABASE_NAME",
+                    "value": "bitnami_wordpress"
+                  },
+                  {
+                    "name": "ALLOW_EMPTY_PASSWORD",
+                    "value": "yes"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "servicenamechange-wordpress-data",
+                    "mountPath": "/bitnami/wordpress"
+                  },
+                  {
+                    "name": "servicenamechange-apache-data",
+                    "mountPath": "/bitnami/apache"
+                  },
+                  {
+                    "name": "servicenamechange-php-data",
+                    "mountPath": "/bitnami/php"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-wordpress-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-wordpress-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-apache-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-apache-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-php-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-php-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/service-name-change/output-os.json
+++ b/script/test/fixtures/service-name-change/output-os.json
@@ -1,0 +1,419 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mariadb"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "mariadb"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          },
+          {
+            "name": "443",
+            "port": 443,
+            "targetPort": 443
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mariadb"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "mariadb"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "mariadb:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "mariadb"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "mariadb"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "servicenamechange-mariadb-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-mariadb-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": " ",
+                "env": [
+                  {
+                    "name": "MARIADB_USER",
+                    "value": "bn_wordpress"
+                  },
+                  {
+                    "name": "MARIADB_DATABASE",
+                    "value": "bitnami_wordpress"
+                  },
+                  {
+                    "name": "ALLOW_EMPTY_PASSWORD",
+                    "value": "yes"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "servicenamechange-mariadb-data",
+                    "mountPath": "/bitnami/mariadb"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mariadb",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mariadb"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "bitnami/mariadb:latest"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-mariadb-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-mariadb-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "wordpress"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "wordpress:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "wordpress"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "wordpress"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "servicenamechange-wordpress-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-wordpress-data"
+                }
+              },
+              {
+                "name": "servicenamechange-apache-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-apache-data"
+                }
+              },
+              {
+                "name": "servicenamechange-php-data",
+                "persistentVolumeClaim": {
+                  "claimName": "servicenamechange-php-data"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "wordpress",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  },
+                  {
+                    "containerPort": 443
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MARIADB_HOST",
+                    "value": "mariadb"
+                  },
+                  {
+                    "name": "MARIADB_PORT",
+                    "value": "3306"
+                  },
+                  {
+                    "name": "WORDPRESS_DATABASE_USER",
+                    "value": "bn_wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DATABASE_NAME",
+                    "value": "bitnami_wordpress"
+                  },
+                  {
+                    "name": "ALLOW_EMPTY_PASSWORD",
+                    "value": "yes"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "servicenamechange-wordpress-data",
+                    "mountPath": "/bitnami/wordpress"
+                  },
+                  {
+                    "name": "servicenamechange-apache-data",
+                    "mountPath": "/bitnami/apache"
+                  },
+                  {
+                    "name": "servicenamechange-php-data",
+                    "mountPath": "/bitnami/php"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "bitnami/wordpress:latest"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-wordpress-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-wordpress-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-apache-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-apache-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "servicenamechange-php-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "servicenamechange-php-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
If we have a `docker-file` with root level `volumes` and we do a `kompose up` using that `docker-file`, libcompose will add an additional `_` followed by the current directory name. 

`docker-compose.yml` used 
```yaml
version: '2'
services:
  mariadb:
    image: 'bitnami/mariadb:latest'
    volumes:
      - 'mariadb-data:/bitnami/mariadb'
    environment:
      - MARIADB_USER=bn_wordpress
      - MARIADB_DATABASE=bitnami_wordpress
      - ALLOW_EMPTY_PASSWORD=yes
  wordpress:
    image: 'bitnami/wordpress:latest'
    ports:
      - '80:80'
      - '443:443'
    volumes:
      - 'wordpress-data:/bitnami/wordpress'
      - 'apache-data:/bitnami/apache'
      - 'php-data:/bitnami/php'
    depends_on:
      - mariadb
    environment:
      - MARIADB_HOST=mariadb
      - MARIADB_PORT=3306
      - WORDPRESS_DATABASE_USER=bn_wordpress
      - WORDPRESS_DATABASE_NAME=bitnami_wordpress
      - ALLOW_EMPTY_PASSWORD=yes
volumes:
  mariadb-data:
    driver: local
  wordpress-data:
    driver: local
  apache-data:
    driver: local
  php-data:
    driver: local
```
```yaml
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    creationTimestamp: null
    labels:
      io.kompose.service: kompose_apache-data
    name: kompose_apache-data
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 100Mi
  status: {}
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    creationTimestamp: null
    labels:
      io.kompose.service: kompose_php-data
    name: kompose_php-data
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 100Mi
  status: {}
kind: List
metadata: {}
```
```bash
$ kompose -f docker-compose.yml up
WARN Unsupported root level volumes key - ignoring 
WARN Unsupported depends_on key - ignoring        
INFO We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. 
 
INFO Deploying application in "default" namespace 
INFO Successfully created Service: mariadb        
INFO Successfully created Service: wordpress      
FATA Error while deploying application: Deployment.extensions "mariadb" is invalid: [spec.template.spec.volumes[0].name: Invalid value: "komposefiles_mariadb-data": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc'), spec.template.spec.containers[0].volumeMounts[0].name: Not found: "komposefiles_mariadb-data"] 
```
Since `kubernetes` doesn't allow `_` in the objects created so `kompose up` will fail to deploy it.

 As a solution we replace `_` to `-` and we can then deploy it successfully. 

```bash
$ kompose -f docker-compose.yml up
WARN Unsupported root level volumes key - ignoring 
WARN Unsupported depends_on key - ignoring        
INFO We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead. 
 
INFO Deploying application in "default" namespace 
INFO Successfully created Service: mariadb        
INFO Successfully created Service: wordpress      
INFO Successfully created Deployment: mariadb     
INFO Successfully created PersistentVolumeClaim: komposefiles-mariadb-data 
INFO Successfully created Deployment: wordpress   
INFO Successfully created PersistentVolumeClaim: komposefiles-wordpress-data 
INFO Successfully created PersistentVolumeClaim: komposefiles-apache-data 
INFO Successfully created PersistentVolumeClaim: komposefiles-php-data 

Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods,pvc' for details.
```
```yaml
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    creationTimestamp: null
    labels:
      io.kompose.service: kompose-apache-data
    name: kompose-apache-data
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 100Mi
  status: {}
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    creationTimestamp: null
    labels:
      io.kompose.service: kompose-php-data
    name: kompose-php-data
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 100Mi
  status: {}
kind: List
metadata: {}
```

CC: @kadel @cdrage  
Fixes #550 