### PR TITLE
Add test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,6 @@ matrix:
     - go: 1.7
     - go: 1.8
 
-before_install:
-  - go get github.com/mattn/goveralls
-  - go get github.com/modocache/gover
-  - go get github.com/Masterminds/glide
-  - go get github.com/sgotti/glide-vc
-  - go get github.com/golang/lint/golint
-
 install:
   - true
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,16 @@ check-vendor:
 
 # Run all tests
 .PHONY: test
-test: check-vendor validate test-unit-cover install test-cmd
+test: test-dep check-vendor validate test-unit-cover install test-cmd
+
+# Install all the required test-dependencies before executing tests (only valid when running `make test`)
+.PHONY: test-dep
+test-dep:
+	go get github.com/mattn/goveralls
+	go get github.com/modocache/gover
+	go get github.com/Masterminds/glide
+	go get github.com/sgotti/glide-vc
+	go get github.com/golang/lint/golint
 
 # build docker image that is used for running all test localy
 .PHONY: test-image


### PR DESCRIPTION
This clears up .travis.yaml as well as adds the test dependencies when
running `make test` so the user running the tests has the most
up-to-date ones available.