### PR TITLE
sort output when creating kubernetes/openshift objects

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -41,6 +41,7 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"sort"
 )
 
 /**
@@ -541,4 +542,14 @@ func (k *Kubernetes) VolumesFrom(objects *[]runtime.Object, komposeObject kobjec
 		}
 	}
 	return nil
+}
+
+//Ensure the kubernetes objects are in a consistent order
+func SortedKeys(komposeObject kobject.KomposeObject) []string {
+	var sortedKeys []string
+	for name := range komposeObject.ServiceConfigs {
+		sortedKeys = append(sortedKeys, name)
+	}
+	sort.Strings(sortedKeys)
+	return sortedKeys
 }

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"reflect"
 )
 
 /*
@@ -273,5 +274,25 @@ func TestRecreateStrategyWithVolumesPresent(t *testing.T) {
 					deployment.Spec.Strategy.Type)
 			}
 		}
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+	}
+	service1 := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+	}
+	c := []string{"a", "b"}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"b": service, "a": service1},
+	}
+	a := SortedKeys(komposeObject)
+	if !reflect.DeepEqual(a, c) {
+		t.Logf("Test Fail output should be %s", c)
 	}
 }

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -19,7 +19,6 @@ package kubernetes
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strconv"
 	"time"
 
@@ -533,13 +532,7 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 	// this will hold all the converted data
 	var allobjects []runtime.Object
 
-	// Need to ensure the kubernetes objects are in a consistent order
-	var sortedKeys []string
-	for name := range komposeObject.ServiceConfigs {
-		sortedKeys = append(sortedKeys, name)
-	}
-	sort.Strings(sortedKeys)
-
+	sortedKeys := SortedKeys(komposeObject)
 	for _, name := range sortedKeys {
 		service := komposeObject.ServiceConfigs[name]
 		var objects []runtime.Object

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -339,7 +339,9 @@ func (o *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 	buildRepo := opt.BuildRepo
 	buildBranch := opt.BuildBranch
 
-	for name, service := range komposeObject.ServiceConfigs {
+	sortedKeys := kubernetes.SortedKeys(komposeObject)
+	for _, name := range sortedKeys {
+		service := komposeObject.ServiceConfigs[name]
 		var objects []runtime.Object
 
 		// Generate pod only and nothing more


### PR DESCRIPTION
The objects created by `kompose` are not in order according to the `services` in `docker-compose` file. This makes it confusing to read the output of `kompose convert --stdout`. 
I have tested it with several `docker-compose` files to make sure it works as, we prefer `Service` to be deployed first as per `kubernetes` best practices.

cc: @cdrage @surajssd 
Fixes: #554 