### PR TITLE
Kompose should show an error when image is not given

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -181,6 +181,9 @@ func (k *Kubernetes) InitD(name string, service kobject.ServiceConfig, replicas 
 			},
 		},
 	}
+	if service.Image == "" && service.Build != "" {
+		log.Fatalf("Error while converting, image required for service %s", name)
+	}
 	return dc
 }
 


### PR DESCRIPTION
kompose passes a kubernetes deployment without image, we should give an error about it.
Fixes: #571  

cc: @surajssd @cdrage 