### PR TITLE
Add Support for cap_add & cap_drop

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -6,7 +6,7 @@ This document outlines all the conversion details regarding `docker-compose.yaml
 |-------------------|---------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | __SERVICE__ |  |  |  |  |
 | build |  | Y | OpenShift: [BuildConfig](https://docs.openshift.com/enterprise/3.1/dev_guide/builds.html#defining-a-buildconfig) | Converts, but local builds are not yet supported. See issue [97](https://github.com/kubernetes-incubator/kompose/issues/97) |
-| cap_add, cap_drop |  | N |  |  |
+| cap_add, cap_drop |  | Y | [Pod.Spec.Container.SecurityContext.Capabilities.Add/Drop](https://kubernetes.io/docs/api-reference/v1.6/#capabilities-v1-core) |  |
 | command |  | Y | [Pod.Spec.Container.Command](https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_container) |  |
 | cgroup_parent |  | N |  | No compatibility with Kubernetes / OpenShift. Limited use-cases with Docker. |
 | container_name |  | Y | Mapped to both [Metadata.Name](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md) and [Deployment.Spec.Containers.Name](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md) |  |

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -51,8 +51,6 @@ func checkUnsupportedKey(composeProject *project.Project) []string {
 	// to make sure that unsupported key is not going to be reported twice
 	// by keeping record if already saw this key in another service
 	var unsupportedKey = map[string]bool{
-		"CapAdd":        false,
-		"CapDrop":       false,
 		"CgroupParent":  false,
 		"CPUSet":        false,
 		"CPUShares":     false,

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -361,6 +361,9 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 	// Configure the container ports.
 	ports := k.ConfigPorts(name, service)
 
+	// Configure capabilities
+	capabilities := k.ConfigCapabilities(service)
+
 	// Configure annotations
 	annotations := transformer.ConfigAnnotations(service)
 
@@ -399,6 +402,11 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 				securityContext.RunAsUser = &uid
 			}
 
+		}
+
+		//set capabilities if it is not empty
+		if len(capabilities.Add) > 0 || len(capabilities.Drop) > 0 {
+			securityContext.Capabilities = capabilities
 		}
 
 		// update template only if securityContext is not empty

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -331,6 +331,22 @@ func (k *Kubernetes) ConfigServicePorts(name string, service kobject.ServiceConf
 	return servicePorts
 }
 
+//ConfigCapabilities configure POSIX capabilities that can be added or removed to a container
+func (k *Kubernetes) ConfigCapabilities(service kobject.ServiceConfig) *api.Capabilities {
+	capsAdd := []api.Capability{}
+	capsDrop := []api.Capability{}
+	for _, capAdd := range service.CapAdd {
+		capsAdd = append(capsAdd, api.Capability(capAdd))
+	}
+	for _, capDrop := range service.CapDrop {
+		capsDrop = append(capsDrop, api.Capability(capDrop))
+	}
+	return &api.Capabilities{
+		Add:  capsAdd,
+		Drop: capsDrop,
+	}
+}
+
 // ConfigTmpfs configure the tmpfs.
 func (k *Kubernetes) ConfigTmpfs(name string, service kobject.ServiceConfig) ([]api.VolumeMount, []api.Volume) {
 	//initializing volumemounts and volumes


### PR DESCRIPTION
Fixes #575
This commit Add support for cap_add & cap_drop which maps to
Pod.Spec.Container.SecurityContext.Capabilities.Add/Drop
Added unit tests for ConfigCapabilities function
Updated conversion.md on support for these keys