### PR TITLE
Update the release script again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ kompose
 bin
 /docker-compose.yaml
 /docker-compose.yml
+changes.txt
 
 #
 # GO SPECIFIC


### PR DESCRIPTION
Updates the release script to use the actual GOPATH directory as
previous problems with commit hashes / versions in `kompose version`.

Cleans this up in regards to all the `cd` and `cd ..` commands.

No need to `git clone`.