### PR TITLE
Failing when port is specified with labels

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -367,6 +367,7 @@ The currently supported options are:
 | kompose.service.type | nodeport / clusterip / loadbalancer |
 | kompose.service.expose| true / hostname |
 
+**Note**: `kompose.service.type` label should be defined with `ports` only, otherwise `kompose` will fail.
 
 ## Restart
 

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -323,3 +323,27 @@ func TestNormalizeServiceNames(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckLabelsPorts(t *testing.T) {
+	testCases := []struct {
+		name        string
+		noOfPort    int
+		labels      string
+		svcName     string
+		expectError bool
+	}{
+		{"ports is defined", 1, "NodePort", "foo", false},
+		{"ports is not defined", 0, "NodePort", "foo", true},
+	}
+
+	var err error
+	for _, testcase := range testCases {
+		t.Log(testcase.name)
+		err = checkLabelsPorts(testcase.noOfPort, testcase.labels, testcase.svcName)
+		if testcase.expectError && err == nil {
+			t.Log("Expected error, got ", err)
+
+		}
+
+	}
+}

--- a/pkg/loader/compose/v1v2.go
+++ b/pkg/loader/compose/v1v2.go
@@ -242,6 +242,10 @@ func libComposeToKomposeMapping(composeObject *project.Project) (kobject.Kompose
 				serviceConfig.ExposeService = strings.ToLower(value)
 			}
 		}
+		err = checkLabelsPorts(len(serviceConfig.Port), composeServiceConfig.Labels["kompose.service.type"], name)
+		if err != nil {
+			return kobject.KomposeObject{}, errors.Wrap(err, "kompose.service.type can't be set if service doesn't expose any ports.")
+		}
 
 		// convert compose labels to annotations
 		serviceConfig.Annotations = map[string]string(composeServiceConfig.Labels)
@@ -265,4 +269,11 @@ func libComposeToKomposeMapping(composeObject *project.Project) (kobject.Kompose
 		}
 	}
 	return komposeObject, nil
+}
+
+func checkLabelsPorts(noOfPort int, labels string, svcName string) error {
+	if noOfPort == 0 && labels == "NodePort" || labels == "LoadBalancer" {
+		return errors.Errorf("%s defined in service %s with no ports present. Issues may occur when bringing up artifacts.", labels, svcName)
+	}
+	return nil
 }

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -200,6 +200,10 @@ convert::expect_success_and_warning "kompose --provider openshift -f $KOMPOSE_RO
 # Test regarding validating dockerfilepath
 convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/dockerfilepath/docker-compose.yml convert --stdout"
 
+# Test regarding while label (nodeport or loadbalancer ) is provided but not ports
+convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/label-port/docker-compose.yml convert --stdout"
+
+
 ######
 # Test the output file behavior of kompose convert
 # Default behavior without -o

--- a/script/test/fixtures/label-port/docker-compose.yml
+++ b/script/test/fixtures/label-port/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+  webapiapplication:
+    image: webapiapplication
+    labels:
+      kompose.service.type: NodePort


### PR DESCRIPTION
Resolves #522
Kompose will give FATAL error if labels are given but ports are not defined