### PR TITLE
update generated artifacts for k8s and openshift so that env variables are loaded in a particular order

### DIFF
--- a/script/test/fixtures/etherpad/output-k8s.json
+++ b/script/test/fixtures/etherpad/output-k8s.json
@@ -86,10 +86,6 @@
                 ],
                 "env": [
                   {
-                    "name": "DB_USER",
-                    "value": "etherpad"
-                  },
-                  {
                     "name": "DB_DBID",
                     "value": "etherpad"
                   },
@@ -104,6 +100,10 @@
                   {
                     "name": "DB_PORT",
                     "value": "3306"
+                  },
+                  {
+                    "name": "DB_USER",
+                    "value": "etherpad"
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/gitlab/docker-compose.yml
+++ b/script/test/fixtures/gitlab/docker-compose.yml
@@ -30,4 +30,4 @@ services:
   redis:
     image: swordphilic/redis
     ports:
-      - "$REDIS_PORT"
+      - $REDIS_PORT

--- a/script/test/fixtures/gitlab/output-k8s.json
+++ b/script/test/fixtures/gitlab/output-k8s.json
@@ -128,10 +128,6 @@
                 ],
                 "env": [
                   {
-                    "name": "REDIS_PORT",
-                    "value": "6379"
-                  },
-                  {
                     "name": "DB_HOST",
                     "value": "postgresql"
                   },
@@ -158,6 +154,10 @@
                   {
                     "name": "REDIS_HOST",
                     "value": "redis"
+                  },
+                  {
+                    "name": "REDIS_PORT",
+                    "value": "6379"
                   }
                 ],
                 "resources": {}
@@ -201,15 +201,15 @@
                 ],
                 "env": [
                   {
-                    "name": "DB_USER",
-                    "value": "gitlab"
-                  },
-                  {
                     "name": "DB_NAME",
                     "value": "gitlab"
                   },
                   {
                     "name": "DB_PASS",
+                    "value": "gitlab"
+                  },
+                  {
+                    "name": "DB_USER",
                     "value": "gitlab"
                   }
                 ],

--- a/script/test/fixtures/keyonly-envs/output-k8s.json
+++ b/script/test/fixtures/keyonly-envs/output-k8s.json
@@ -112,20 +112,20 @@
                 ],
                 "env": [
                   {
-                    "name": "SESSION_SECRET",
-                    "value": "session"
-                  },
-                  {
-                    "name": "SHOW",
-                    "value": "true"
-                  },
-                  {
                     "name": "GET_HOSTS_FROM",
                     "value": "dns"
                   },
                   {
                     "name": "RACK_ENV",
                     "value": "development"
+                  },
+                  {
+                    "name": "SESSION_SECRET",
+                    "value": "session"
+                  },
+                  {
+                    "name": "SHOW",
+                    "value": "true"
                   }
                 ],
                 "resources": {}
@@ -216,12 +216,12 @@
                     "value": "development"
                   },
                   {
-                    "name": "SHOW",
-                    "value": "true"
-                  },
-                  {
                     "name": "SESSION_SECRET",
                     "value": "session"
+                  },
+                  {
+                    "name": "SHOW",
+                    "value": "true"
                   }
                 ],
                 "resources": {}

--- a/script/test/fixtures/multiple-compose-files/output-k8s.json
+++ b/script/test/fixtures/multiple-compose-files/output-k8s.json
@@ -177,19 +177,19 @@
                 ],
                 "env": [
                   {
-                    "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "MYSQL_USER",
-                    "value": "openshift"
-                  },
-                  {
                     "name": "MYSQL_DATABASE",
                     "value": "openshift"
                   },
                   {
                     "name": "MYSQL_PASSWORD",
+                    "value": "openshift"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "openshift"
+                  },
+                  {
+                    "name": "MYSQL_USER",
                     "value": "openshift"
                   }
                 ],

--- a/script/test/fixtures/multiple-compose-files/output-openshift.json
+++ b/script/test/fixtures/multiple-compose-files/output-openshift.json
@@ -124,6 +124,10 @@
                 ],
                 "env": [
                   {
+                    "name": "DB_DBID",
+                    "value": "openshift"
+                  },
+                  {
                     "name": "DB_HOST",
                     "value": "openshift"
                   },
@@ -137,10 +141,6 @@
                   },
                   {
                     "name": "DB_USER",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "DB_DBID",
                     "value": "openshift"
                   }
                 ],
@@ -255,10 +255,6 @@
                 ],
                 "env": [
                   {
-                    "name": "MYSQL_USER",
-                    "value": "openshift"
-                  },
-                  {
                     "name": "MYSQL_DATABASE",
                     "value": "openshift"
                   },
@@ -268,6 +264,10 @@
                   },
                   {
                     "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "openshift"
+                  },
+                  {
+                    "name": "MYSQL_USER",
                     "value": "openshift"
                   }
                 ],


### PR DESCRIPTION
Fixes: #595 
cc: @surajssd 