### PR TITLE
Remove 1.6 and 1.7 testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ go_import_path: github.com/kubernetes-incubator/kompose
 
 matrix:
   include:
-    - go: 1.6
-      # Only build docs once
-      env: BUILD_DOCS=yes
-    - go: 1.7
     - go: 1.8
+      env: BUILD_DOCS=yes
 
 install:
   - true


### PR DESCRIPTION
Let's speed up travis by only testing against 1.8.

There hasn't been any problems with other version (1.6 and 1.7)
and Travis has been unbearibly slow.

Let's switch to only doing 1.8 (since Travis at times refuses to do all
three concurrently!).