### PR TITLE
Replace underscores with dashes while rendering container names

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -317,7 +317,11 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 		serviceConfig := kobject.ServiceConfig{}
 		serviceConfig.Image = composeServiceConfig.Image
 		serviceConfig.Build = composeServiceConfig.Build.Context
-		serviceConfig.ContainerName = composeServiceConfig.ContainerName
+		newName := normalizeServiceNames(composeServiceConfig.ContainerName)
+		serviceConfig.ContainerName = newName
+		if newName != composeServiceConfig.ContainerName {
+			log.Infof("Container name in service %q has been changed from %q to %q", name, composeServiceConfig.ContainerName, newName)
+		}
 		serviceConfig.Command = composeServiceConfig.Entrypoint
 		serviceConfig.Args = composeServiceConfig.Command
 		serviceConfig.Dockerfile = composeServiceConfig.Build.Dockerfile


### PR DESCRIPTION
Kubernetes container names must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])?
This excludes underscores, which is common in container names in compose. Given this docker compose file
```
version: '2'
services:
  app:
    build: app
    container_name: forest_app
    image: app
```
Before this patch, compose generates this deployment
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  name: app
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        io.kompose.service: app
    spec:
      containers:
      - image: app
        name: forest_app
        resources: {}
      restartPolicy: Always
status: {}
```
After the patch, it generates
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  name: app
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        io.kompose.service: app
    spec:
      containers:
      - image: app
        name: forest-app
        resources: {}
      restartPolicy: Always
status: {}
```
The CLI output:
```
# ./kompose -f test.yaml convert
INFO Container name in docker-compose has been changed from "forest_app" to "forest-app"
WARN Kubernetes provider doesn't support build key - ignoring
INFO file "app-service.yaml" created
INFO file "app-deployment.yaml" created
```