### PR TITLE
Update `kompose completion`

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -12,18 +12,15 @@ import (
 
 var completion = &cobra.Command{
 	Use:   "completion SHELL",
-	Short: "Generate a bash auto completion file",
-	Long: `Generate a bash auto completion script.
+	Short: "Output shell completion code",
+	Long: `Generates shell completion code.
 
-	Auto completion supports both bash and zsh.
+Auto completion supports both bash and zsh. Output is to STDOUT.
 
-	The output is to stdout.
+source <(kompose completion bash)
+source <(kompose completion zsh)
 
-	Examples:
-	$ source <(kompose completion bash)
-	$ source <(kompose completion zsh)
-
-	Will load the bash completion code.
+Will load the shell completion code.
 	`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Updates Kompose completion with neutral language (using shell instead of
bash).

Fixes the indentation issues when outputting `kompose completion --help`