### PR TITLE
Fix incorrect tag in BuildConfig.

### DIFF
--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -245,7 +245,7 @@ func initBuildConfig(name string, service kobject.ServiceConfig, repo string, br
 				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "ImageStreamTag",
-						Name: name + ":latest",
+						Name: name + ":" + getImageTag(service.Image),
 					},
 				},
 			},

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -281,43 +281,67 @@ func TestGetAbsBuildContext(t *testing.T) {
 
 // Test initializing buildconfig for a service
 func TestInitBuildConfig(t *testing.T) {
-	dir := testutils.CreateLocalGitDirectory(t)
-	testutils.CreateSubdir(t, dir, "a/build")
-	defer os.RemoveAll(dir)
-
 	serviceName := "serviceA"
-	repo := "https://git.test.com/org/repo"
+	repo := "https://git.test.com/org/repo1"
 	branch := "somebranch"
 	buildArgs := []kapi.EnvVar{{Name: "name", Value: "value"}}
 	value := "value"
-	sc := kobject.ServiceConfig{
-		Build:      filepath.Join(dir, "a/build"),
-		Dockerfile: "Dockerfile-alternate",
-		BuildArgs:  map[string]*string{"name": &value},
-	}
-	bc, err := initBuildConfig(serviceName, sc, repo, branch)
-	if err != nil {
-		t.Error(errors.Wrap(err, "initBuildConfig failed"))
+	testDir := "a/build"
+
+	dir := testutils.CreateLocalGitDirectory(t)
+	testutils.CreateSubdir(t, dir, testDir)
+	defer os.RemoveAll(dir)
+
+	testCases := []struct {
+		Name          string
+		ServiceConfig kobject.ServiceConfig
+	}{
+		{
+			Name: "Service config without image key",
+			ServiceConfig: kobject.ServiceConfig{
+				Build:      filepath.Join(dir, testDir),
+				Dockerfile: "Dockerfile-alternate",
+				BuildArgs:  map[string]*string{"name": &value},
+			},
+		},
+		{
+			Name: "Service config with image key",
+			ServiceConfig: kobject.ServiceConfig{
+				Build:      filepath.Join(dir, testDir),
+				Dockerfile: "Dockerfile-alternate",
+				BuildArgs:  map[string]*string{"name": &value},
+				Image:      "foo:bar",
+			},
+		},
 	}
 
-	testCases := map[string]struct {
-		field string
-		value string
-	}{
-		"Assert buildconfig source git URI":     {bc.Spec.CommonSpec.Source.Git.URI, repo},
-		"Assert buildconfig source git Ref":     {bc.Spec.CommonSpec.Source.Git.Ref, branch},
-		"Assert buildconfig source context dir": {bc.Spec.CommonSpec.Source.ContextDir, "a/build/"},
-		"Assert buildconfig output name":        {bc.Spec.CommonSpec.Output.To.Name, serviceName + ":latest"},
-		"Assert buildconfig dockerfilepath":     {bc.Spec.CommonSpec.Strategy.DockerStrategy.DockerfilePath, "Dockerfile-alternate"},
-	}
-	for name, test := range testCases {
-		t.Log("Test case: ", name)
-		if test.field != test.value {
-			t.Errorf("Expected: %#v, got: %#v", test.value, test.field)
+	for _, test := range testCases {
+
+		bc, err := initBuildConfig(serviceName, test.ServiceConfig, repo, branch)
+		if err != nil {
+			t.Error(errors.Wrap(err, "initBuildConfig failed"))
 		}
-	}
-	if !reflect.DeepEqual(bc.Spec.CommonSpec.Strategy.DockerStrategy.Env, buildArgs) {
-		t.Errorf("Expected: %#v, got: %#v", bc.Spec.CommonSpec.Strategy.DockerStrategy.Env, buildArgs)
+
+		assertions := map[string]struct {
+			field string
+			value string
+		}{
+			"Assert buildconfig source git URI":     {bc.Spec.CommonSpec.Source.Git.URI, repo},
+			"Assert buildconfig source git Ref":     {bc.Spec.CommonSpec.Source.Git.Ref, branch},
+			"Assert buildconfig source context dir": {bc.Spec.CommonSpec.Source.ContextDir, testDir + "/"},
+			// BuildConfig output image is named after service name. If image key is set than tag from that is used.
+			"Assert buildconfig output name":    {bc.Spec.CommonSpec.Output.To.Name, serviceName + ":" + getImageTag(test.ServiceConfig.Image)},
+			"Assert buildconfig dockerfilepath": {bc.Spec.CommonSpec.Strategy.DockerStrategy.DockerfilePath, test.ServiceConfig.Dockerfile},
+		}
+
+		for name, assertionTest := range assertions {
+			if assertionTest.field != assertionTest.value {
+				t.Errorf("%s Expected: %#v, got: %#v", name, assertionTest.value, assertionTest.field)
+			}
+		}
+		if !reflect.DeepEqual(bc.Spec.CommonSpec.Strategy.DockerStrategy.Env, buildArgs) {
+			t.Errorf("Expected: %#v, got: %#v", bc.Spec.CommonSpec.Strategy.DockerStrategy.Env, buildArgs)
+		}
 	}
 }
 


### PR DESCRIPTION
For services with build and image keys DeploymentConfig respects tag from docker-compose image key.
But BuildConfig image tag was always set to  'latest'.
Result of this was that deployment wasn't trigired after successful build.
This fixes it by setting BuildConfig output image tag to the same tag that is used for  DeploymentConfig (tag from docker-compose image key)

fixes #611 