### PR TITLE
Add provider to file output

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -198,7 +198,7 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 		if err != nil {
 			return fmt.Errorf("Error in marshalling the List: %v", err)
 		}
-		printVal, err := transformer.Print("", dirName, "", data, opt.ToStdout, opt.GenerateJSON, f)
+		printVal, err := transformer.Print("", dirName, "", data, opt.ToStdout, opt.GenerateJSON, f, opt.Provider)
 		if err != nil {
 			return errors.Wrap(err, "transformer.Print failed")
 		}
@@ -225,7 +225,7 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 			// cast it to correct type - api.ObjectMeta
 			objectMeta := val.FieldByName("ObjectMeta").Interface().(api.ObjectMeta)
 
-			file, err = transformer.Print(objectMeta.Name, dirName, strings.ToLower(typeMeta.Kind), data, opt.ToStdout, opt.GenerateJSON, f)
+			file, err = transformer.Print(objectMeta.Name, dirName, strings.ToLower(typeMeta.Kind), data, opt.ToStdout, opt.GenerateJSON, f, opt.Provider)
 			if err != nil {
 				return errors.Wrap(err, "transformer.Print failed")
 			}

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -115,7 +115,7 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 }
 
 // Print either prints to stdout or to file/s
-func Print(name, path string, trailing string, data []byte, toStdout, generateJSON bool, f *os.File) (string, error) {
+func Print(name, path string, trailing string, data []byte, toStdout, generateJSON bool, f *os.File, provider string) (string, error) {
 	file := ""
 	if generateJSON {
 		file = fmt.Sprintf("%s-%s.json", name, trailing)
@@ -137,7 +137,17 @@ func Print(name, path string, trailing string, data []byte, toStdout, generateJS
 		if err := ioutil.WriteFile(file, []byte(data), 0644); err != nil {
 			return "", errors.Wrap(err, "Failed to write %s: "+trailing)
 		}
-		log.Printf("file %q created", file)
+		log.Printf("%s file %q created", formatProviderName(provider), file)
 	}
 	return file, nil
+}
+
+// If Openshift, change to OpenShift!
+func formatProviderName(provider string) string {
+	if strings.EqualFold(provider, "openshift") {
+		return "OpenShift"
+	} else if strings.EqualFold(provider, "kubernetes") {
+		return "Kubernetes"
+	}
+	return provider
 }

--- a/pkg/transformer/utils_test.go
+++ b/pkg/transformer/utils_test.go
@@ -21,6 +21,15 @@ import (
 	"testing"
 )
 
+func TestFormatProviderName(t *testing.T) {
+	if formatProviderName("openshift") != "OpenShift" {
+		t.Errorf("Got %s, expected OpenShift", formatProviderName("openshift"))
+	}
+	if formatProviderName("kubernetes") != "Kubernetes" {
+		t.Errorf("Got %s, expected Kubernetes", formatProviderName("kubernetes"))
+	}
+}
+
 // When passing "z" or "Z" we expect "" back.
 func TestZParseVolumeLabeling(t *testing.T) {
 	testCase := "/foobar:/foobar:Z"


### PR DESCRIPTION
Adds the provider name to the file output. For example:

```sh
INFO OpenShift file "frontend-service.yaml" created
INFO OpenShift file "redis-master-service.yaml" created
INFO OpenShift file "redis-slave-service.yaml" created
INFO OpenShift file "frontend-deploymentconfig.yaml" created
INFO OpenShift file "frontend-imagestream.yaml" created
INFO OpenShift file "redis-master-deploymentconfig.yaml" created
INFO OpenShift file "redis-master-imagestream.yaml" created
INFO OpenShift file "redis-slave-deploymentconfig.yaml" created
INFO OpenShift file "redis-slave-imagestream.yaml" created
```