### PR TITLE
Disable dab

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,4 +102,8 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayVarP(&GlobalFiles, "file", "f", []string{}, "Specify an alternative compose file")
 	RootCmd.PersistentFlags().StringVarP(&GlobalBundle, "bundle", "b", "", "Specify a Distributed Application Bundle (DAB) file")
 	RootCmd.PersistentFlags().StringVar(&GlobalProvider, "provider", "kubernetes", "Specify a provider. Kubernetes or OpenShift.")
+
+	// Mark DAB / bundle as deprecated, see issue: https://github.com/kubernetes-incubator/kompose/issues/390
+	// As DAB is still EXPERIMENTAL
+	RootCmd.PersistentFlags().MarkDeprecated("bundle", "DAB / Bundle is deprecated, see: https://github.com/kubernetes-incubator/kompose/issues/390")
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -118,6 +118,7 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 
 	if len(bundle) > 0 {
 		inputFormat = "bundle"
+		log.Fatalf("DAB / bundle (--bundle | -b) is no longer supported. See issue: https://github.com/kubernetes-incubator/kompose/issues/390")
 		opt.InputFiles = []string{bundle}
 	}
 

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -119,11 +119,10 @@ convert::expect_failure "kompose down $KOMPOSE_ROOT/script/test/fixtures/gitlab/
 convert::expect_failure "kompose convert $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml -j" "Unknown Argument docker-gitlab.yml"
 
 # Tests related to kompose --bundle convert usage and that setting the compose file results in a failure
-convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/bundles/foo.yml --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert"
-
-######
-# Test related to kompose --bundle convert to ensure that docker bundles are converted properly
-convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dab/output-k8s.json"
+# We no longer test --bundle, however, this command may come back in the future thus we are keeping the test commented
+# convert::expect_failure "kompose -f $KOMPOSE_ROOT/script/test/fixtures/bundles/foo.yml --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert"
+# convert::expect_success "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dab/docker-compose-bundle.dab convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dab/output-k8s.json"
+# convert::expect_success_and_warning "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/docker-voting-bundle.dsb convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/output-k8s.json"  "Unsupported Networks key - ignoring"
 
 # Test related to multiple-compose files
 # Kubernets test
@@ -131,9 +130,6 @@ convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtur
 # OpenShift test
 convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-k8s.yml -f $KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/docker-os.yml convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/multiple-compose-files/output-openshift.json" "Unsupported depends_on key - ignoring"
 
-######
-# Test related to kompose --bundle convert to ensure that DSB bundles are converted properly
-convert::expect_success_and_warning "kompose --bundle $KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/docker-voting-bundle.dsb convert --stdout -j" "$KOMPOSE_ROOT/script/test/fixtures/bundles/dsb/output-k8s.json"  "Unsupported Networks key - ignoring"
 
 ######
 # Test related to restart options in docker-compose


### PR DESCRIPTION
See issue: https://github.com/kubernetes-incubator/kompose/issues/390

Remove DAB as it is hard to maintain / not much usage / DAB is still
experimental in Docker and there hasn't been much movement:
https://github.com/moby/moby/issues/26876

MarkDeprecated does not work at the moment due to issue:
https://github.com/kubernetes-incubator/kompose/issues/652

However, that is not a blocker as we `fatalF` within `ValidateFlags`