### PR TITLE
Adding Jenkinsfile for PR pipeline on Fabric8CD infrastructure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,13 @@
+@Library('github.com/fabric8io/fabric8-pipeline-library@master')
+def dummy
+goTemplate{
+  dockerNode{
+      goMake{
+        githubOrganisation = 'kubernetes-incubator'
+        dockerOrganisation = 'fabric8'
+        project = 'kompose'
+        makeCommand = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/usr/local/glide:/usr/local/:/go/bin:/home/jenkins/go/bin \
+                       && bash script/test/cmd/fix_detached_head.sh && make test"
+      }
+  }
+}


### PR DESCRIPTION
Initial commit adding Jenkinsfile for pr pipeline on fabric8CD(http://jenkins.cd.k8s.fabric8.io/job/kubernetes-incubator/)

This PR includes a Jenkinsfile which just does `make test` for now which will run the tests on every PR and on merge with master.
It uses golang version 1.8.1

The below things are not covered which are there in .travis.yml:
1. It does not test with the Matrix of various versions of go lang.
2. It does not do the coverage 
3. It does not sync the docs