### PR TITLE
Adds redirection plugin for website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,7 @@ author_name: The Kubernetes Authors
 author_url: https://github.com/kubernetes-incubator/kompose
 
 markdown: kramdown
+
+# Redirection plugin
+gems:
+  - jekyll-redirect-from


### PR DESCRIPTION
Fixes redirection issues when adding links such as `/docs/` to the
documentation