### PR TITLE
Fix redirection site issues

### DIFF
--- a/script/sync-docs.sh
+++ b/script/sync-docs.sh
@@ -65,6 +65,7 @@ for filename in *.md; do
     jekyll="---
 layout: default
 permalink: /$name/
+redirect_from: \"/docs/$name/\"
 ---
 "
     echo -e "$jekyll\n$(cat $filename)" > $filename


### PR DESCRIPTION
Fixes the issues in regards to rediction.

For example, supplying `/docs/conversion` within the user guide the link
will appear as a 404.

Adding this allows redirection from `/docs/conversion` to `/conversion`.