### PR TITLE
Add mention bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,11 @@
+{
+  "maxReviewers": 3, // 3 is enough
+  "numFilesToCheck": 5,
+  "message": "@pullRequester, thanks! @reviewers, please review this.",
+  "findPotentialReviewers": true,
+  "fileBlacklist": ["*.md"], // ignore documentation
+  "userBlacklist": ["ngtuna", "janetkuo", "sebgoa"], // explicitly ignore pinging alumni
+  "assignToReviewer": false,
+  "createReviewRequest": true,
+  "createComment": true,
+}


### PR DESCRIPTION
In order to deploy https://github.com/facebook/mention-bot it's good to
have a .mention-bot file in the root directory.

This PR adds that said file as well as creates a user blacklist so
maintainer alumni aren't needlessly pinged.