### PR TITLE
Update mention bot configuration to avoid mentioning people twice

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,7 +1,9 @@
 {
   "numFilesToCheck": 10,
-  "message": "@pullRequester, thanks! @reviewers, please review this.",
+  "message": "@pullRequester, thank you for the pull request! We'll ping some people to review your PR. @reviewers, please review this.",
   "fileBlacklist": ["*.md"],
   "userBlacklist": ["ngtuna", "janetkuo", "sebgoa"],
-  "actions": ["opened", "labeled"]
+  "actions": ["opened", "labeled"],
+  "skipAlreadyMentionedPR": true,
+  "createReviewRequest": true
 }


### PR DESCRIPTION
This updates the config to avoid mentioning people twice as well as
assinging people appropriately.