### PR TITLE
remove unused parameter from ValidateComposeFile()

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -88,7 +88,7 @@ var convertCmd = &cobra.Command{
 
 		// Validate before doing anything else. Use "bundle" if passed in.
 		app.ValidateFlags(GlobalBundle, args, cmd, &ConvertOpt)
-		app.ValidateComposeFile(cmd, &ConvertOpt)
+		app.ValidateComposeFile(&ConvertOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -45,7 +45,7 @@ var downCmd = &cobra.Command{
 		}
 
 		// Validate before doing anything else.
-		app.ValidateComposeFile(cmd, &DownOpt)
+		app.ValidateComposeFile(&DownOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app.Down(DownOpt)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -60,7 +60,7 @@ var upCmd = &cobra.Command{
 		}
 
 		// Validate before doing anything else.
-		app.ValidateComposeFile(cmd, &UpOpt)
+		app.ValidateComposeFile(&UpOpt)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		app.Up(UpOpt)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -136,7 +136,7 @@ func ValidateFlags(bundle string, args []string, cmd *cobra.Command, opt *kobjec
 }
 
 // ValidateComposeFile validated the compose file provided for conversion
-func ValidateComposeFile(cmd *cobra.Command, opt *kobject.ConvertOptions) {
+func ValidateComposeFile(opt *kobject.ConvertOptions) {
 	if len(opt.InputFiles) == 0 {
 		// Here docker-compose is the input
 		opt.InputFiles = []string{"docker-compose.yml"}


### PR DESCRIPTION
In pkg/app/app.go, the function ValidateComposeFile() has an
unused parameter "cmd *cobra.Command".

This commit removes that parameter from the function and the
callers of the function.